### PR TITLE
Fix #if Conditional Logix

### DIFF
--- a/Sources/LeafKit/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerializer.swift
@@ -68,7 +68,7 @@ struct LeafSerializer {
         }
         
         let resolver = ParameterResolver(params: list, data: data)
-        let satisfied = try resolver.resolve().map { $0.result.bool ?? false } .reduce(false) { $0 || $1 }
+        let satisfied = try resolver.resolve().map { $0.result.bool ?? !$0.result.isNull } .reduce(true) { $0 && $1 }
         if satisfied {
             try serialize(body: conditional.body)
         } else if let next = conditional.next {

--- a/Sources/LeafKit/ParameterResolver.swift
+++ b/Sources/LeafKit/ParameterResolver.swift
@@ -115,7 +115,7 @@ struct ParameterResolver {
     private func resolve(op: Operator, rhs: LeafData) throws -> LeafData {
         switch op {
         case .not:
-            let result = rhs.bool ?? false
+            let result = rhs.bool ?? !rhs.isNull
             return .init(.bool(!result))
         default:
             throw "unexpected left hand operator not supported: \(op)"
@@ -127,12 +127,12 @@ struct ParameterResolver {
         case .not:
             throw "single expression operator"
         case .and:
-            let lhs = lhs.bool ?? false
-            let rhs = rhs.bool ?? false
+            let lhs = lhs.bool ?? !lhs.isNull
+            let rhs = rhs.bool ?? !rhs.isNull
             return .init(.bool(lhs && rhs))
         case .or:
-            let lhs = lhs.bool ?? false
-            let rhs = rhs.bool ?? false
+            let lhs = lhs.bool ?? !lhs.isNull
+            let rhs = rhs.bool ?? !rhs.isNull
             return .init(.bool(lhs || rhs))
         case .equals:
             return .init(.bool(lhs == rhs))

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -141,6 +141,60 @@ final class LeafTests: XCTestCase {
         """
         try XCTAssertEqual(render(template, ["id": 42, "name": "Tanner"]), "User 42!")
     }
+    
+    func testStringIf() throws {
+        let template = """
+        #if(name):Hello, #(name)!#else:No Name!#endif
+        """
+        let expectedName = "Hello, Tanner!"
+        let expectedNoName = "No Name!"
+        try XCTAssertEqual(render(template, ["name": .string("Tanner")]), expectedName)
+        try XCTAssertEqual(render(template), expectedNoName)
+    }
+    
+    func testEqualIf() throws {
+        let template = """
+        #if(string1 == string2):Good#else:Bad#endif
+        """
+        let expectedGood = "Good"
+        let expectedBad = "Bad"
+        try XCTAssertEqual(render(template, ["string1": .string("Tanner"), "string2": .string("Tanner")]), expectedGood)
+        try XCTAssertEqual(render(template, ["string1": .string("Tanner"), "string2": .string("n/a")]), expectedBad)
+    }
+    
+    func testAndStringIf() throws {
+        let template = """
+        #if(name && one):Hello, #(name)#(one)!#elseif(name):Hello, #(name)!#else:No Name!#endif
+        """
+        let expectedNameOne = "Hello, Tanner1!"
+        let expectedName = "Hello, Tanner!"
+        let expectedNoName = "No Name!"
+        try XCTAssertEqual(render(template, ["name": .string("Tanner"), "one": .string("1")]), expectedNameOne)
+        try XCTAssertEqual(render(template, ["name": .string("Tanner")]), expectedName)
+        try XCTAssertEqual(render(template), expectedNoName)
+    }
+    
+    func testOrStringIf() throws {
+        let template = """
+        #if(name || one):Hello, #(name)#(one)!#else:No Name!#endif
+        """
+        let expectedName = "Hello, Tanner!"
+        let expectedOne = "Hello, 1!"
+        let expectedNoName = "No Name!"
+        try XCTAssertEqual(render(template, ["name": .string("Tanner")]), expectedName)
+        try XCTAssertEqual(render(template, ["one": .string("1")]), expectedOne)
+        try XCTAssertEqual(render(template), expectedNoName)
+    }
+    
+    func testArrayIf() throws {
+        let template = """
+        #if(namelist):#for(name in namelist):Hello, #(name)!#endfor#else:No Name!#endif
+        """
+        let expectedName = "Hello, Tanner!"
+        let expectedNoName = "No Name!"
+        try XCTAssertEqual(render(template, ["namelist": [.string("Tanner")]]), expectedName)
+        try XCTAssertEqual(render(template), expectedNoName)
+    }
 //
 //    func testEscapeExtraneousBody() throws {
 //        let template = """
@@ -202,13 +256,6 @@ final class LeafTests: XCTestCase {
 //        let context = TemplateData.dictionary(["foo": .double(1_337_000)])
 //        try XCTAssertEqual(renderer.testRender(template, context), expected)
 //
-//    }
-//
-//    func testStringIf() throws {
-//        let template = "#if(name){Hello, #(name)!}"
-//        let expected = "Hello, Tanner!"
-//        let context = TemplateData.dictionary(["name": .string("Tanner")])
-//        try XCTAssertEqual(renderer.testRender(template, context), expected)
 //    }
 //
 //    func testEmptyForLoop() throws {


### PR DESCRIPTION
Fixes `#if` to support checking a value's truthiness like Leaf 3 did (#28, fixes #31). 
- Fix null handling for conditionals
- Fix boolean reduction for future parameter lists with > 1 boolean values
- Restored and updated leaf3 "testStringIf" test
- Added tests for conditional and/or