### PR TITLE
Add support for nested key paths in loops

### DIFF
--- a/Sources/LeafKit/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerializer.swift
@@ -100,7 +100,29 @@ struct LeafSerializer {
     }
     
     mutating func serialize(_ loop: Syntax.Loop) throws {
-        guard let array = data[loop.array]?.array else { throw "expected array at key: \(loop.array)" }
+        let finalData: [String: LeafData]
+        let pathComponents = loop.array.split(separator: ".")
+        
+        if pathComponents.count > 1 {
+            finalData = try pathComponents[0..<(pathComponents.count - 1)].enumerated()
+                .reduce(data) { (innerData, pathContext) -> [String: LeafData] in
+                    let key = String(pathContext.element)
+                    
+                    guard let nextData = innerData[key]?.dictionary else {
+                        let currentPath = pathComponents[0...pathContext.offset].joined(separator: ".")
+                        throw "expected dictionary at key: \(currentPath)"
+                    }
+                    
+                    return nextData
+                }
+        } else {
+            finalData = data
+        }
+        
+        guard let array = finalData[String(pathComponents.last!)]?.array else {
+            throw "expected array at key: \(loop.array)"
+        }
+        
         for (idx, item) in array.enumerated() {
             var innerContext = self.data
             

--- a/Tests/LeafKitTests/SerializeTests.swift
+++ b/Tests/LeafKitTests/SerializeTests.swift
@@ -35,4 +35,67 @@ final class SerializerTests: XCTestCase {
 //        let output = syntax.map { $0.description } .joined(separator: "\n")
 //        XCTAssertEqual(output, expectation)
     }
+    
+    func testNestedKeyPathLoop() throws {
+        let input = """
+        #for(person in people):
+        hello #(person.name)
+        #for(skill in person.skills):
+        you're pretty good at #(skill)
+        #endfor
+        #endfor
+        """
+        
+        let syntax = try! altParse(input)
+        let people = LeafData(.array([
+            LeafData(.dictionary([
+                "name": "LOGAN",
+                "skills": LeafData(.array([
+                    "running",
+                    "walking"
+                ]))
+            ]))
+        ]))
+        
+        var serializer = LeafSerializer(ast: syntax, context: ["people": people])
+        var serialized = try serializer.serialize()
+        let str = (serialized.readString(length: serialized.readableBytes) ?? "<err>")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        XCTAssertEqual(str, """
+        hello LOGAN
+
+        you're pretty good at running
+
+        you're pretty good at walking
+        """)
+    }
+    
+    func testInvalidNestedKeyPathLoop() throws {
+        let input = """
+        #for(person in people):
+        hello #(person.name)
+        #for(skill in person.profile.skills):
+        you're pretty good at #(skill)
+        #endfor
+        #endfor
+        """
+        
+        let syntax = try! altParse(input)
+        let people = LeafData(.array([
+            LeafData(.dictionary([
+                "name": "LOGAN",
+                "skills": LeafData(.array([
+                    "running",
+                    "walking"
+                ]))
+            ]))
+        ]))
+        
+        var serializer = LeafSerializer(ast: syntax, context: ["people": people])
+        
+        XCTAssertThrowsError(try serializer.serialize()) { error in
+            XCTAssertEqual("\(error)", "expected dictionary at key: person.profile")
+        }
+    }
 }


### PR DESCRIPTION
Added support for using nested paths when specifying the right-hand expression of a for loop in Leaf templates.

For example with the following code:

```swift
struct Show: Content {
    let title: String
    let cast: [CastMember]
    
    struct CastMember: Content {
        let name: String
        let characterName: String
    }
}

let thirthyRock = Show(title: "30 Rock", cast: [
    Show.CastMember(name: "Tina Fey", characterName: "Liz Lemon"),
    Show.CastMember(name: "Alec Baldwin", characterName: "Jack Donaghy"),
    ...
])

...
req.view.render("ShowInfo", [thirthyRock])
...
```
It is now possible to use a Leaf template such as:
```
#for(show in shows):
    <h2>#(show.title)</h2>
    <h4>Cast</h2>
    #for(castMember in show.cast):
        <p>#(castMember.name) as #(castMember.characterName)</p>
    #endfor
#endfor
```