### PR TITLE
Add requirement methods to LeafContext

### DIFF
--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -73,6 +73,29 @@ public struct LeafContext {
         self.body = body
         self.userInfo = userInfo
     }
+
+    /// Throws an error if the parameter count does not equal the supplied number `n`.
+    public func requireParameterCount(_ n: Int) throws {
+        guard parameters.count == n else {
+            throw "Invalid parameter count: \(parameters.count)/\(n)"
+        }
+    }
+
+    /// Throws an error if this tag does not include a body.
+    public func requireBody() throws -> [Syntax] {
+        guard let body = body else {
+            throw "Missing body"
+        }
+
+        return body
+    }
+
+    /// Throws an error if this tag includes a body.
+    public func requireNoBody() throws {
+        guard body == nil else {
+            throw "Extraneous body"
+        }
+    }
 }
 
 public protocol LeafTag {


### PR DESCRIPTION
Adds methods to `LeafContext` to verify the existence, or non-existence of a context body, as well as to verify the context contains a specific number of parameters.