### PR TITLE
Add Underscore as Valid in Parameter

### DIFF
--- a/Sources/LeafKit/Exports.swift
+++ b/Sources/LeafKit/Exports.swift
@@ -31,6 +31,7 @@ extension Character {
     static let greaterThan = ">".first!
     static let ampersand = "&".first!
     static let vertical = "|".first!
+    static let underscore = "_".first!
     
     var isUppercaseLetter: Bool {
         return (.A ... .Z).contains(self)

--- a/Sources/LeafKit/LeafLexer.swift
+++ b/Sources/LeafKit/LeafLexer.swift
@@ -10,6 +10,7 @@ extension Character {
             || self.isValidOperator
             || (.zero ... .nine) ~= self
             || self == .period
+            || self == .underscore
     }
     
     var isValidOperator: Bool {

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -515,7 +515,7 @@ final class LexerTests: XCTestCase {
     }
     
     func testParameters() throws {
-        let input = "#(foo == 40, and, \"literal\")"
+        let input = "#(foo == 40, and, \"literal\", and, foo_bar)"
         let expectation = """
         tagIndicator
         tag(name: "")
@@ -527,6 +527,10 @@ final class LexerTests: XCTestCase {
         param(variable(and))
         parameterDelimiter
         param(stringLiteral("literal"))
+        parameterDelimiter
+        param(variable(and))
+        parameterDelimiter
+        param(variable(foo_bar))
         parametersEnd
 
         """


### PR DESCRIPTION
Adds `underscore` to `Character` extension, then ORs `.underscore` in `isValidInParameter` (#41, fixes #39).