### PR TITLE
Limited Cache Control (Purge Cached Templates)

### DIFF
--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -245,7 +245,7 @@ public final class LeafRenderer {
         guard cache.isEnabled else { return self.read(file: expanded) }
         // if caching is on, attempt to load cached ResolvedDocument.
         // if cached is nil, read file, otherwise return cached file.        
-        return cache.load(documentName: expanded, on: eventLoop).flatMap { [unowned self] cached in
+        return cache.load(documentName: expanded, on: eventLoop).flatMap { cached in
             guard let cached = cached else { return self.read(file: expanded) }
             return self.eventLoop.makeSucceededFuture(cached)
         }
@@ -263,7 +263,7 @@ public final class LeafRenderer {
             return try parser.parse()
         }
         
-        return syntax.flatMap { [unowned self] syntax in
+        return syntax.flatMap { syntax in
             let dependencies = self.readDependencies(syntax.dependencies)
             let resolved = dependencies.flatMapThrowing { dependencies -> ResolvedDocument in
                 let unresolved = UnresolvedDocument(name: file, raw: syntax)
@@ -273,7 +273,7 @@ public final class LeafRenderer {
 
             guard self.cache.isEnabled else { return resolved }
             
-            return resolved.flatMap { [unowned self] resolved in
+            return resolved.flatMap { resolved in
                 self.cache.insert(resolved, on: self.eventLoop, replace: false)
             }
         }

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -26,11 +26,11 @@ public protocol LeafCache {
     /// - return nil if cache entry didn't exist in the first place, true if purged
     /// - will never return false in this design but should be capable of it
     ///   in the event a cache implements dependency tracking between templates
-	func remove(
+    func remove(
         _ documentName: String,
         on loop: EventLoop
     ) -> EventLoopFuture<Bool?>
-	
+
     var isEnabled : Bool { get set }
 }
 
@@ -64,7 +64,7 @@ public final class DefaultLeafCache: LeafCache {
         defer { self.lock.unlock() }
         return loop.makeSucceededFuture(self.cache[documentName])
     }
-	
+
     public func remove(
         _ documentName: String,
         on loop: EventLoop
@@ -75,7 +75,7 @@ public final class DefaultLeafCache: LeafCache {
         guard self.cache[documentName] != nil else { return loop.makeSucceededFuture(nil) }
         self.cache[documentName] = nil
         return loop.makeSucceededFuture(true)
-	}
+    }
 }
 
 public struct LeafContext {

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -17,17 +17,17 @@ public protocol LeafCache {
         _ document: ResolvedDocument,
         on loop: EventLoop
     ) -> EventLoopFuture<ResolvedDocument>
-	
+
     func load(
         documentName: String,
         on loop: EventLoop
     ) -> EventLoopFuture<ResolvedDocument?>
-	
+
     /// - return nil if cache entry didn't exist in the first place, true if purged
     /// - will never return false in this design but should be capable of it
     ///   in the event a cache implements dependency tracking between templates
-	@discardableResult func purge(
-        _ name: String,
+	func remove(
+        _ documentName: String,
         on loop: EventLoop
     ) -> EventLoopFuture<Bool?>
 	
@@ -65,16 +65,16 @@ public final class DefaultLeafCache: LeafCache {
         return loop.makeSucceededFuture(self.cache[documentName])
     }
 	
-	@discardableResult public func purge(
-        _ name: String,
+    public func remove(
+        _ documentName: String,
         on loop: EventLoop
     ) -> EventLoopFuture<Bool?> {
         self.lock.lock()
         defer { self.lock.unlock() }
-        
-        guard self.cache[name] != nil else { return loop.makeSucceededFuture(nil) }
-        self.cache[name] = nil
-		return loop.makeSucceededFuture(true)
+
+        guard self.cache[documentName] != nil else { return loop.makeSucceededFuture(nil) }
+        self.cache[documentName] = nil
+        return loop.makeSucceededFuture(true)
 	}
 }
 


### PR DESCRIPTION
This extends LeafCache's protocol, and DefaultLeafCache implementation, to add a .remove method to allow selective purging of cached view templates in order to allow refreshing template declarations without restarting the server.

Extension to LeafCache protocol:
```swift
public protocol LeafCache {
    // existing protocols interfaces here...

    func remove(_ documentName: String, on loop: EventLoop) -> EventLoopFuture<Bool?>
}
```
- Drops the ResolvedDocument for "name" template from the cache and returns an optional Bool future
- Return meanings: 
  - true: removed
  - false: not removed *never returned in current design*
  - nil: no cached document existed 

Issues:
- Views dependent on other views via #extend("template") resolve at the time they're loaded and will not refresh the extended template portion - solving this would require a dependency graph on the cache, which would be nice in the future. This is the case in which false would be returned.
- View name must be fully qualified (eg, "/RootDirectory/Views/path/to/template.leaf" and not "path/to/template" because the name expansion methods are internal to LeafRenderer and not accessible to LeafCache.