### PR TITLE
Add default Leaf tags for loop indices

### DIFF
--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -1,9 +1,5 @@
 import NIOConcurrencyHelpers
 
-public var defaultTags: [String: LeafTag] = [
-    "lowercased": Lowercased(),
-]
-
 public struct LeafConfiguration {
     public var rootDirectory: String
     
@@ -95,19 +91,6 @@ public struct LeafContext {
         guard body == nil else {
             throw "Extraneous body"
         }
-    }
-}
-
-public protocol LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData
-}
-
-struct Lowercased: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
-        guard let str = ctx.parameters.first?.string else {
-            throw "unable to lowercase unexpected data"
-        }
-        return .init(.string(str.lowercased()))
     }
 }
 

--- a/Sources/LeafKit/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerializer.swift
@@ -137,8 +137,9 @@ struct LeafSerializer {
         for (idx, item) in array.enumerated() {
             var innerContext = self.data
             
-            if idx == 0 { innerContext["isFirst"] = .bool(true) }
-            else if idx == array.count - 1 { innerContext["isLast"] = .bool(true) }
+            innerContext["isFirst"] = .bool(idx == 0)
+            innerContext["isLast"] = .bool(idx == array.count - 1)
+            innerContext["index"] = .int(idx)
             innerContext[loop.item] = item
             
             var serializer = LeafSerializer(

--- a/Sources/LeafKit/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerializer.swift
@@ -137,8 +137,8 @@ struct LeafSerializer {
         for (idx, item) in array.enumerated() {
             var innerContext = self.data
             
-            innerContext["isFirst"] = .bool(idx == 0)
-            innerContext["isLast"] = .bool(idx == array.count - 1)
+            innerContext["isFirst"] = .bool(idx == array.startIndex)
+            innerContext["isLast"] = .bool(idx == array.index(before: array.endIndex))
             innerContext["index"] = .int(idx)
             innerContext[loop.item] = item
             

--- a/Sources/LeafKit/LeafTag.swift
+++ b/Sources/LeafKit/LeafTag.swift
@@ -3,10 +3,7 @@ public protocol LeafTag {
 }
 
 public var defaultTags: [String: LeafTag] = [
-    "lowercased": Lowercased(),
-    "index": LoopIndex(),
-    "isFirst": LoopIsFirst(),
-    "isLast": LoopIsLast()
+    "lowercased": Lowercased()
 ]
 
 struct Lowercased: LeafTag {
@@ -15,26 +12,5 @@ struct Lowercased: LeafTag {
             throw "unable to lowercase unexpected data"
         }
         return .init(.string(str.lowercased()))
-    }
-}
-
-struct LoopIndex: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
-        guard let index = ctx.data["index"] else { throw "Loop accessor called on non-loop" }
-        return index
-    }
-}
-
-struct LoopIsFirst: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
-        guard let isFirst = ctx.data["isFirst"] else { throw "Loop accessor called on non-loop" }
-        return isFirst
-    }
-}
-
-struct LoopIsLast: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
-        guard let isLast = ctx.data["isLast"] else { throw "Loop accessor called on non-loop" }
-        return isLast
     }
 }

--- a/Sources/LeafKit/LeafTag.swift
+++ b/Sources/LeafKit/LeafTag.swift
@@ -1,0 +1,40 @@
+public protocol LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData
+}
+
+public var defaultTags: [String: LeafTag] = [
+    "lowercased": Lowercased(),
+    "index": LoopIndex(),
+    "isFirst": LoopIsFirst(),
+    "isLast": LoopIsLast()
+]
+
+struct Lowercased: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        guard let str = ctx.parameters.first?.string else {
+            throw "unable to lowercase unexpected data"
+        }
+        return .init(.string(str.lowercased()))
+    }
+}
+
+struct LoopIndex: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        guard let index = ctx.data["index"] else { throw "Loop accessor called on non-loop" }
+        return index
+    }
+}
+
+struct LoopIsFirst: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        guard let isFirst = ctx.data["isFirst"] else { throw "Loop accessor called on non-loop" }
+        return isFirst
+    }
+}
+
+struct LoopIsLast: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        guard let isLast = ctx.data["isLast"] else { throw "Loop accessor called on non-loop" }
+        return isLast
+    }
+}

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -418,6 +418,19 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template, [:]), expected)
     }
     
+    // Current implementation favors context keys over tag keys, so
+    // defining a key for isFirst in context will override accessing registered
+    // LeafTags with the same name.
+    // More reason to introduce scoping tag keys!!
+    func testTagContextOverride() throws {
+        let template = """
+            #if(isFirst):Wrong (Maybe)#else:Right#endif
+            """
+            let expected = "Wrong (Maybe)"
+        
+        try XCTAssertEqual(render(template, ["isFirst": true]), expected)
+    }
+    
 //
 //    // https://github.com/vapor/leaf/issues/99
 //    func testGH99() throws {


### PR DESCRIPTION
### Changes:
- Breaks LeafTag protocol definition into its own file for clarity
- Adds tag definitions for index, isFirst and isLast inside loops
- Add relevant tests
- Works correctly with both flat and nested arrays
- Resolves #45 

### Issues:
- Can only refer to the current level when nested; would be nice to be able to scope it to the loop level.


Unrelated to this PR, but noted that colon popping when parsing always tries to force reading a body, so `#(index): #(item)` tries to assign a body to the tag for index. Tags that can't take parameters should probably be able to disregard this during parsing, I'd think?