### PR TITLE
LeafRenderer.resolve Recursive Resolution of LeafAST

### DIFF
--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -317,7 +317,7 @@ public final class LeafRenderer {
             // create new AST with loaded references
             let new = LeafAST(from: ast, referencing: externals)
             // Check new AST's unresolved refs to see if extension introduced new refs
-            if new.unresolvedRefs.subtracting(ast.unresolvedRefs).count != 0 {
+            if !new.unresolvedRefs.subtracting(ast.unresolvedRefs).isEmpty {
                 // AST has new references - try to resolve again recursively
                 return self.resolve(ast: new, chain: chain)
             } else {

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -314,9 +314,16 @@ public final class LeafRenderer {
                     case .failure(let e): return self.eventLoop.makeFailedFuture(e)
                 }
             }
-            // return new inlined AST that may potentially still have references that can't be resolved
+            // create new AST with loaded references
             let new = LeafAST(from: ast, referencing: externals)
-            return self.cache.insert(new, on: self.eventLoop, replace: true )
+            // Check new AST's unresolved refs to see if extension introduced new refs
+            if new.unresolvedRefs.subtracting(ast.unresolvedRefs).count != 0 {
+                // AST has new references - try to resolve again recursively
+                return self.resolve(ast: new, chain: chain)
+            } else {
+                // Cache extended AST & return - AST is either flat or unresolvable
+                return self.cache.insert(new, on: self.eventLoop, replace: true)
+            }
         }
     }
 


### PR DESCRIPTION
In cases where `extend` introduces new external references (eg, via import/export as in Issue #33 ), recursively resolve the AST until no new dependencies exist.