### PR TITLE
Robustify - Improved/Extended Lexing Behavior & Error Handling

### DIFF
--- a/Sources/LeafKit/Exports.swift
+++ b/Sources/LeafKit/Exports.swift
@@ -39,7 +39,7 @@ extension Character {
     static let vertical = "|".first!
     static let underscore = "_".first!
     
-    var isHexidecimal: Bool {
+    var isHexadecimal: Bool {
         return (.zero ... .nine).contains(self)
             || (.A ... .F).contains(self.uppercased().first!)
             || self == .hexNotation

--- a/Sources/LeafKit/Exports.swift
+++ b/Sources/LeafKit/Exports.swift
@@ -14,12 +14,18 @@ extension Character {
     static let colon = ":".first!
     static let period = ".".first!
     static let A = "A".first!
+    static let F = "F".first!
     static let Z = "Z".first!
     static let a = "a".first!
     static let z = "z".first!
     
     static let zero = "0".first!
+    static let one = "1".first!
+    static let seven = "7".first!
     static let nine = "9".first!
+    static let binaryNotation = "b".first!
+    static let octalNotation = "o".first!
+    static let hexNotation = "x".first!
     
     static let plus = "+".first!
     static let minus = "-".first!
@@ -32,6 +38,22 @@ extension Character {
     static let ampersand = "&".first!
     static let vertical = "|".first!
     static let underscore = "_".first!
+    
+    var isHexidecimal: Bool {
+        return (.zero ... .nine).contains(self)
+            || (.A ... .F).contains(self.uppercased().first!)
+            || self == .hexNotation
+    }
+    
+    var isOctal: Bool {
+        return (.zero ... .seven).contains(self)
+        || self == .octalNotation
+    }
+    
+    var isBinary: Bool {
+        return (.zero ... .one).contains(self)
+        || self == .binaryNotation
+    }
     
     var isUppercaseLetter: Bool {
         return (.A ... .Z).contains(self)

--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -1,0 +1,102 @@
+/// `Error` types and helper types for reporting and analyzing errors during template processing/rendering/
+
+public struct LeafError: Error {
+    public enum Reason {
+        /// Errors related to LeafCache access
+        /// Attempts to modify cache entries when caching is globally disabled
+        case cachingDisabled
+        /// Attemps to insert a cache entry when one exists and replacing is not set to true
+        case keyExists(String)
+        /// Attempts to modify cache for a non-existant key
+        /// *NOTE* NOT used when accessing as Optional returns are adequately clear
+        case noValueForKey(String)
+        
+        /// Errors related to rendering a template
+        /// Attempts to render a non-flat AST - provide template name & array of unresolved references
+        case unresolvedAST(String, [String])
+        /// Attempts to render a non-existant template - provide template name
+        case noTemplateExists(String)
+        /// Attempts to render an AST with cyclical external references - provide template name & ordered array of cycle
+        case cyclicalReference(String, [String])
+        
+        /// Errors due to malformed template syntax or grammar
+        case lexerError(LexerError)
+        /// Errors from protocol adherents that do not support newer features
+        case unsupportedFeature(String)
+        /// Errors only when no existing error reason is adequately clear
+        case unknownError(String)
+    }
+    
+    public let file: String
+    public let function: String
+    public let line: UInt
+    public let column: UInt
+    public let reason: Reason
+
+    var localizedDescription: String {
+        var verbose = ""
+        let file = self.file.split(separator: "/").last
+        
+        switch self.reason {
+            case .lexerError: verbose += "Lexing error - "
+        default: verbose += "\(file ?? "?").\(function):\(line) - "
+        }
+        
+        switch self.reason {
+            case .unknownError(let message): verbose += message
+            case .unsupportedFeature(let feature): verbose +=  "\(feature) is not implemented"
+            case .cachingDisabled: verbose +=  "Caching is globally disabled"
+            case .keyExists(let key): verbose +=  "Existing entry \(key); use insert with replace=true to overrride"
+            case .noValueForKey(let key): verbose +=  "No cache entry exists for \(key)"
+            case .unresolvedAST(let key, let dependencies):
+                verbose +=  "Flat AST expected; \(key) has unresolved dependencies: \(dependencies)"
+            case .noTemplateExists(let key): verbose +=  "No template found for \(key)"
+            case .cyclicalReference(let key, let chain):
+                verbose +=  "\(key) cyclically referenced in [\(chain.joined(separator: " -> "))]"
+            case .lexerError(let e): verbose +=  e.localizedDescription
+        }
+        
+        return verbose
+    }
+
+    internal init(
+        _ reason: Reason,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        column: UInt = #column
+    ) {
+        self.file = file
+        self.function = function
+        self.line = line
+        self.column = column
+        self.reason = reason
+    }
+}
+
+
+public struct LexerError: Error {
+    public enum Reason {
+        case invalidTagToken(Character)
+        case invalidParameterToken(Character)
+        case unterminatedStringLiteral
+    }
+    
+    public let line: Int
+    public let column: Int
+    public let name: String
+    public let reason: Reason
+    public let lexed: [LeafToken]
+    
+    internal init(src: TemplateSource, lexed: [LeafToken], reason: Reason) {
+        self.line = src.line
+        self.column = src.column
+        self.reason = reason
+        self.lexed = lexed
+        self.name = src.name
+    }
+    
+    var localizedDescription: String {
+        return "\"\(name)\"; \(reason) - \(line):\(column)"
+    }
+}

--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -80,6 +80,8 @@ public struct LexerError: Error {
         case invalidTagToken(Character)
         case invalidParameterToken(Character)
         case unterminatedStringLiteral
+        // Use below in place of fatalError to indicate extreme issue
+        case internalError(String)
     }
     
     public let line: Int
@@ -87,13 +89,20 @@ public struct LexerError: Error {
     public let name: String
     public let reason: Reason
     public let lexed: [LeafToken]
+    internal let recoverable: Bool
     
-    internal init(src: TemplateSource, lexed: [LeafToken], reason: Reason) {
+    internal init(
+        _ reason: Reason,
+        src: TemplateSource,
+        lexed: [LeafToken] = [],
+        recoverable: Bool = false
+    ) {
         self.line = src.line
         self.column = src.column
         self.reason = reason
         self.lexed = lexed
         self.name = src.name
+        self.recoverable = recoverable
     }
     
     var localizedDescription: String {

--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -39,7 +39,7 @@ public struct LeafError: Error {
         
         switch self.reason {
             case .lexerError: verbose += "Lexing error - "
-        default: verbose += "\(file ?? "?").\(function):\(line) - "
+            default: verbose += "\(file ?? "?").\(function):\(line) - "
         }
         
         switch self.reason {
@@ -106,6 +106,6 @@ public struct LexerError: Error {
     }
     
     var localizedDescription: String {
-        return "\"\(name)\"; \(reason) - \(line):\(column)"
+        return "\"\(name)\": \(reason) - \(line):\(column)"
     }
 }

--- a/Sources/LeafKit/LeafLexer.swift
+++ b/Sources/LeafKit/LeafLexer.swift
@@ -79,28 +79,6 @@ struct TemplateSource {
     }
 }
 
-public struct LexerError: Error {
-    public enum Reason {
-        case invalidTagToken(Character)
-        case invalidParameterToken(Character)
-        case unterminatedStringLiteral
-    }
-    
-    public let line: Int
-    public let column: Int
-    public let name: String
-    public let reason: Reason
-    public let lexed: [LeafToken]
-    
-    internal init(src: TemplateSource, lexed: [LeafToken], reason: Reason) {
-        self.line = src.line
-        self.column = src.column
-        self.reason = reason
-        self.lexed = lexed
-        self.name = src.name
-    }
-}
-
 struct LeafLexer {
     private enum State {
         // parses as raw, until it finds `#` (excluding escaped `\#`)

--- a/Sources/LeafKit/LeafLexer.swift
+++ b/Sources/LeafKit/LeafLexer.swift
@@ -5,12 +5,23 @@ extension Character {
     }
     
     var isValidInParameter: Bool {
-        return self.isLowercaseLetter
-            || self.isUppercaseLetter
+        return self.isValidInTagName
             || self.isValidOperator
-            || (.zero ... .nine) ~= self
-            || self == .period
+            || self.isValidInNumeric
+    }
+       
+    var canStartNumeric: Bool {
+        return (.zero ... .nine) ~= self
+    }
+    
+    var isValidInNumeric: Bool {
+        return self.canStartNumeric
             || self == .underscore
+            || self == .binaryNotation
+            || self == .octalNotation
+            || self == .hexNotation
+            || self.isHexidecimal
+            || self == .period
     }
     
     var isValidOperator: Bool {
@@ -46,15 +57,34 @@ struct TemplateSource {
     }
     
     mutating func readWhile(_ check: (Character) -> Bool) -> String? {
-        return readSliceWhile(check).flatMap { String($0) }
+        return readSliceWhile(pop: true, check).flatMap { String($0) }
     }
     
-    mutating func readSliceWhile(_ check: (Character) -> Bool) -> [Character]? {
+    mutating func peekWhile(_ check: (Character) -> Bool) -> String? {
+        return peekSliceWhile(check).flatMap { String($0) }
+    }
+    
+    mutating func popWhile(_ check: (Character) -> Bool) -> Int {
+        return readSliceWhile(pop: true, check)?.count ?? 0
+    }
+    
+    mutating func readSliceWhile(pop: Bool, _ check: (Character) -> Bool) -> [Character]? {
         var str = [Character]()
         while let next = peek() {
             guard check(next) else { return str }
-            pop()
+            if pop { self.pop() }
             str.append(next)
+        }
+        return str
+    }
+    
+    mutating func peekSliceWhile(_ check: (Character) -> Bool) -> [Character]? {
+        var str = [Character]()
+        var index = 0
+        while let next = peek(aheadBy: index) {
+            guard check(next) else { return str }
+            str.append(next)
+            index += 1
         }
         return str
     }
@@ -82,16 +112,17 @@ struct TemplateSource {
 struct LeafLexer {
     private enum State {
         // parses as raw, until it finds `#` (excluding escaped `\#`)
-        case normal
+        case raw
         // found a `#`
         case tag
         // found a `(` continues until `)`
-        case parameters(depth: Int)
+        case parameters
         // parses a tag body
         case body
     }
     
     private var state: State
+    private var depth: Int = 0
     private var lexed: [LeafToken] = []
     private var src: TemplateSource
     private var name: String
@@ -99,7 +130,7 @@ struct LeafLexer {
     init(name: String, template string: String) {
         self.name = name
         self.src = .init(name: name, src: string)
-        self.state = .normal
+        self.state = .raw
     }
     
     mutating func lex() throws -> [LeafToken] {
@@ -110,123 +141,191 @@ struct LeafLexer {
     }
     
     private mutating func nextToken() throws -> LeafToken? {
-        guard let next = src.peek() else { return nil }
+        // if EOF, return nil - no more to read
+        guard let current = src.peek() else { return nil }
+        let isTagID = current == .tagIndicator
+        let isTagVal = current.isValidInTagName
+        let isCol = current == .colon
+        let next = src.peek(aheadBy: 1)
         
-        switch state {
-        case .normal:
-            switch next {
-            case .backSlash:
-                // consume '\' only in event of '\#'
-                // otherwise allow it to remain for other
-                // escapes, a la javascript
-                if src.peek(aheadBy: 1) == .tagIndicator {
-                    src.pop()
-                }
-                // either way, add raw '#' or '\' to registry
-                return src.pop().flatMap { .raw(.init($0)) }
-            case .tagIndicator:
-                // consume `#`
-                src.pop()
-
-                // if tag indicator is followed by an invalid token, assume that it is unrelated to leaf
-                  guard let next = src.peek() else { throw "can not terminate document with tag indicator" }
-                  if next.isValidInTagName || next == .leftParenthesis {
-                      state = .tag
-                      return .tagIndicator
-                  } else {
-                      state = .normal
-                      return .raw(Character.tagIndicator.description)
-                  }
+        switch   (state,       isTagID, isTagVal, isCol, next) {
+            case (.raw,        false,   _,        _,     _):     return lexRaw()
+            case (.raw,        true,    _,        _,     .some): return lexCheckTagIndicator()
+            case (.tag,        _,       true,     _,     _):     return lexNamedTag()
+            case (.tag,        _,       false,    _,     _):     return lexAnonymousTag()
+            case (.parameters, _,   _,   _,  _):                 return try lexParameters()
+            case (.body,       _,   _, true,  _):                return lexBodyIndicator()
+            /// Ambiguous case  - `#endTagName#` at EOF. Should this result in `tag(tagName),raw(#)`?
+            case (.raw,        true,    _,        _,     .none):
+            throw LexerError(.internalError("Unescaped # at EOF"), src: src, lexed: lexed)
             default:
-                // read until next event
-                let slice = src.readWhile { $0 != .tagIndicator && $0 != .backSlash } ?? ""
-                return .raw(slice)
-            }
-        case .tag:
-            switch next {
-            case .leftParenthesis:
-                // '#('
-                state = .parameters(depth: 0)
-                return .tag(name: "")
-            case let x where x.isValidInTagName:
-                // collect the named tag, letters only
-                let val = src.readWhile { $0.isValidInTagName }
-                guard let name = val else { fatalError("switch case should disallow this") }
-                
-                let trailing = src.peek()
-                if trailing == .colon { state = .body }
-                else if trailing == .leftParenthesis { state = .parameters(depth: 0) }
-                else { state = .normal }
-                
-                return .tag(name: name)
-            default:
-                throw LexerError(src: src, lexed: lexed, reason: .invalidTagToken(next))
-            }
-        case .parameters(let depth):
-            switch next {
-            case .leftParenthesis:
+                throw LexerError(.internalError("Template cannot be lexed"), src: src, lexed: lexed)
+        }
+    }
+    
+    // Lexing subroutines that can produce state changes:
+    // * to .raw:           lexRaw, lexCheckTagIndicator
+    // * to .tag:           lexCheckTagIndicator
+    // * to .parameters:    lexAnonymousTag, lexNamedTag
+    // * to .body:          lexNamedTag
+    
+    private mutating func lexAnonymousTag() -> LeafToken {
+        state = .parameters
+        depth = 0
+        return .tag(name: "")
+    }
+    
+    private mutating func lexNamedTag() -> LeafToken {
+        let name = src.readWhile { $0.isValidInTagName } ?? ""
+        let trailing = src.peek()
+        state = .raw
+        if trailing == .colon { state = .body }
+        if trailing == .leftParenthesis { state = .parameters; depth = 0 }
+        return .tag(name: name)
+    }
+    
+    /// Consume all data until hitting an unescaped `tagIndicator` and return a `.raw` token
+    private mutating func lexRaw() -> LeafToken {
+        var slice = ""
+        while let current = src.peek(), current != .tagIndicator {
+            slice += src.readWhile { $0 != .tagIndicator && $0 != .backSlash } ?? ""
+            guard let newCurrent = src.peek(), newCurrent == .backSlash else { break }
+            if let next = src.peek(aheadBy: 1), next == .tagIndicator {
                 src.pop()
-                state = .parameters(depth: depth + 1)
+            }
+            slice += src.pop()!.description
+        }
+        return .raw(slice)
+    }
+    
+    /// Consume `#`, change state to `.tag` or `.raw`, return appropriate token
+    private mutating func lexCheckTagIndicator() -> LeafToken {
+        // consume `#`
+        src.pop()
+        // if tag indicator is followed by an invalid token, assume that it is unrelated to leaf
+        let current = src.peek()
+        if let current = current, current.isValidInTagName || current == .leftParenthesis {
+            state = .tag
+            return .tagIndicator
+        } else {
+            state = .raw
+            return .raw(Character.tagIndicator.description)
+        }
+    }
+        
+    /// Consume `:`, change state to `.raw`, return `.tagBodyIndicator`
+    private mutating func lexBodyIndicator() -> LeafToken {
+        src.pop()
+        state = .raw
+        return .tagBodyIndicator
+    }
+    
+    /// Parameter hot mess
+    private mutating func lexParameters() throws -> LeafToken {
+        // consume first character regardless of what it is
+        let current = src.pop()!
+        
+        // Simple returning cases - .parametersStart/Delimiter/End, .whitespace, .stringLiteral Parameter
+        switch current {
+            case .leftParenthesis:
+                depth += 1
                 return .parametersStart
             case .rightParenthesis:
-                // must pop before subsequent peek
-                src.pop()
-                if depth <= 1 {
-                    if src.peek() == .colon {
-                        state = .body
-                    } else {
-                        state = .normal
-                    }
-                } else {
-                    state = .parameters(depth: depth - 1)
+                switch (depth <= 1, src.peek() == .colon) {
+                    case (true, true): state = .body
+                    case (true, false): state = .raw
+                    case (false, _): depth -= 1
                 }
                 return .parametersEnd
             case .comma:
-                src.pop()
                 return .parameterDelimiter
             case .quote:
-                // consume first quote
-                src.pop()
-                let read = src.readWhile { $0 != .quote && $0 != .newLine }
-                guard let string = read else { fatalError("disallowed by switch") }
+                let read = src.readWhile { $0 != .quote && $0 != .newLine } ?? ""
                 guard src.peek() == .quote else {
-                    throw LexerError(src: src, lexed: lexed, reason: .unterminatedStringLiteral)
+                    throw LexerError(.unterminatedStringLiteral, src: src, lexed: lexed)
                 }
-                // consume final quote
-                src.pop()
-                return .parameter(.stringLiteral(string))
+                src.pop() // consume final quote
+                return .parameter(.stringLiteral(read))
             case .space:
-                // skip whitespace
-                let read = src.readWhile { $0 == .space }
-                guard let space = read else { fatalError("disallowed by switch") }
-                return .whitespace(length: space.count)
-            case let x where x == .exclamation
-                && src.peek(aheadBy: 1)?.isValidOperator == false:
-                // for when ! stands alone
-                src.pop()
-                return .parameter(.operator(.not))
-            case let x where x.isValidInParameter:
-                let read = src.readWhile { $0.isValidInParameter }
-                guard let name = read else { fatalError("disallowed by switch") }
-                // this parameter is a tag
-                if src.peek() == .leftParenthesis { return .parameter(.tag(name: name)) }
-                
-                // check if expected parameter type
-                if let keyword = Keyword(rawValue: name) { return .parameter(.keyword(keyword)) }
-                else if let op = Operator(rawValue: name) { return .parameter(.operator(op)) }
-                else if let val = Int(name) { return .parameter(.constant(.int(val))) }
-                else if let val = Double(name) { return .parameter(.constant(.double(val))) }
-                
-                // unknown param type.. var
-                return .parameter(.variable(name: name))
-            default:
-                throw LexerError(src: src, lexed: lexed, reason: .invalidParameterToken(next))
+                let read = src.readWhile { $0 == .space } ?? ""
+                return .whitespace(length: read.count + 1)
+            default: break
+        }
+        
+        // Complex Parameter lexing situations - enhanced to allow non-whitespace separated values
+        // Complicated by overlap in acceptable isValidInParameter characters between possible types
+        // Process from most restrictive options to least to help prevent overly aggressive tokens
+        // Possible results, most restrictive to least
+        // * Operator
+        // * Constant(Int)
+        // * Constant(Double)
+        // * Keyword
+        // * Tag
+        // * Variable
+        
+        // if current character isn't valid for any kind of parameter, something's majorly wrong
+        guard current.isValidInParameter else {
+            throw LexerError(.invalidParameterToken(current), src: src, lexed: lexed)
+        }
+
+        // Test for Operator first - this will only handle max two character operators, not ideal
+        // Can't switch on this, MUST happen before trying to read tags
+        if current.isValidOperator {
+            var op = Operator(rawValue: String(current) + String(src.peek()!))
+            if op == nil { op = Operator(rawValue: String(current)) } else { src.pop() }
+            if op != nil { return .parameter(.operator(op!)) }
+        }
+        
+        // Test for numerics next. This is not very intelligent but will read base2/8/10/16
+        // for Ints and base 10/16 for decimal through native Swift initialization
+        // Will not adequately decay to handle things like `0b0A` and recognize as invalid.
+        if current.canStartNumeric {
+            let next = src.peek()!
+            let peekRaw = String(current) + (src.peekWhile { $0.isValidInNumeric } ?? "")
+            var peekNum = peekRaw.replacingOccurrences(of: String(.underscore), with: "")
+            // 1 character string must be an integer
+            guard peekNum.count > 1 else { return .parameter(.constant(.int(Int(peekNum)!))) }
+                        
+            var testInt: Int?
+            var testDouble: Double?
+            var radix: Int?
+            
+            switch (peekNum.contains(.period), next, peekNum.count > 2) {
+                case (true, _, _) : testDouble = Double(peekNum)
+                case (false, .binaryNotation, true): radix = 2
+                case (false, .octalNotation, true): radix = 8
+                case (false, .hexNotation, true): radix = 16
+                default: testInt = Int(peekNum)
             }
-        case .body:
-            guard next == .colon else { fatalError("state should only be set to .body when a colon is in queue") }
-            src.pop()
-            state = .normal
-            return .tagBodyIndicator
+            
+            if let radix = radix, radix != 10 {
+                let start = peekNum.startIndex
+                peekNum.removeSubrange(start ... peekNum.index(after: start))
+                testInt = Int(peekNum, radix: radix)
+            }
+            
+            if testInt != nil || testDouble != nil {
+                _ = src.popWhile { $0.isValidInNumeric }
+                if testInt != nil { return .parameter(.constant(.int(testInt!))) }
+                else { return .parameter(.constant(.double(testDouble!))) }
+            }
+        }
+        
+        // At this point, just read anything that's parameter valid, but not an operator,
+        // Could be handled better and is probably way too aggressive.
+        let name = String(current) + (src.readWhile { $0.isValidInParameter && !$0.isValidOperator } ?? "")
+        
+        // If it's a keyword, return that
+        if let keyword = Keyword(rawValue: name) { return .parameter(.keyword(keyword)) }
+        // Assume anything that matches .isValidInTagName is a tag
+        // Parse can decay to a variable if necessary - checking for a paren
+        // is over-aggressive because a custom tag may not take parameters
+        let tagValid = name.compactMap { $0.isValidInTagName ? $0 : nil }.count == name.count
+        
+        if tagValid && src.peek()! == .leftParenthesis {
+            return .parameter(.tag(name: name))
+        } else {
+            return .parameter(.variable(name: name))
         }
     }
 }

--- a/Sources/LeafKit/LeafToken.swift
+++ b/Sources/LeafKit/LeafToken.swift
@@ -23,19 +23,34 @@ public enum Operator: String, Equatable, CustomStringConvertible {
 }
 
 extension Operator {
-    var isBooleanOperator: Bool {
+    var isBoolean: Bool {
         switch self {
-        case .equals,
-             .notEquals,
-             .greaterThan,
-             .greaterThanOrEquals,
-             .lessThan,
-             .lessThanOrEquals,
-             .and,
-             .or:
-            return true
-        default:
-            return false
+            case .not,
+                 .equals,
+                 .notEquals,
+                 .greaterThan,
+                 .greaterThanOrEquals,
+                 .lessThan,
+                 .lessThanOrEquals,
+                 .and,
+                 .or:
+                return true
+            default:
+                return false
+        }
+    }
+    
+    var isBinary: Bool {
+        switch self {
+            case .not: return false
+            default: return true
+        }
+    }
+    
+    var isUnaryPrefix: Bool {
+        switch self {
+            case .not: return true
+            default: return false
         }
     }
 }
@@ -46,8 +61,8 @@ public enum Constant: CustomStringConvertible, Equatable {
     
     public var description: String {
         switch self {
-        case .int(let i): return i.description
-        case .double(let d): return d.description
+            case .int(let i): return i.description
+            case .double(let d): return d.description
         }
     }
 }
@@ -152,7 +167,7 @@ public enum LeafToken: CustomStringConvertible, Equatable  {
     case parameter(Parameter)
     case parametersEnd
     
-    // TODO: RM IF POASIBLE
+    // TODO: RM IF POSSIBLE
     case stringLiteral(String)
     case whitespace(length: Int)
     

--- a/Sources/LeafKit/LeafToken.swift
+++ b/Sources/LeafKit/LeafToken.swift
@@ -4,7 +4,9 @@ public enum Keyword: String, Equatable {
     var isBooleanValued: Bool {
         switch self {
             case .true,
-                 .false
+                 .false,
+                 .yes,
+                 .no
                  : return true
             default: return false
         }
@@ -12,8 +14,8 @@ public enum Keyword: String, Equatable {
     
     var booleanValue: Bool? {
         switch self {
-            case .true: return true
-            case .false: return false
+            case .true, .yes: return true
+            case .false, .no: return false
             default: return nil
         }
     }
@@ -296,10 +298,7 @@ internal extension Array where Element == ParameterDeclaration {
     func binaryOps() -> Int { return reduceOpWhere { $0.isBinary } }
     func reduceOpWhere(_ check: (Operator) -> Bool) -> Int {
         return self.reduce(0, { count, pD  in
-            if let op = pD.operator() {
-                return check(op) ? count + 1 : count
-            }
-            return count
+            return count + (pD.operator().map { check($0) ? 1 : 0 } ?? 0)
         })
     }
     

--- a/Sources/LeafKit/LeafToken.swift
+++ b/Sources/LeafKit/LeafToken.swift
@@ -285,8 +285,8 @@ internal extension Array where Element == ParameterDeclaration {
         let lhs = self[i-1]
         let rhs = self[i+1]
         // can't wrap if lhs or rhs is an operator
-        if case .parameter(let p) = lhs, case .operator = p { return }
-        if case .parameter(let p) = rhs, case .operator = p { return }
+        if case .parameter(.operator) = lhs { return }
+        if case .parameter(.operator) = rhs { return }
         self[i] = .expression([lhs, self[i], rhs])
         self.remove(at:i+1)
         self.remove(at:i-1)       

--- a/Sources/LeafKit/LeafToken.swift
+++ b/Sources/LeafKit/LeafToken.swift
@@ -1,5 +1,22 @@
 public enum Keyword: String, Equatable {
     case `in`, `true`, `false`, `self`, `nil`, `yes`, `no`
+    
+    var isBooleanValued: Bool {
+        switch self {
+            case .true,
+                 .false
+                 : return true
+            default: return false
+        }
+    }
+    
+    var booleanValue: Bool? {
+        switch self {
+            case .true: return true
+            case .false: return false
+            default: return nil
+        }
+    }
 }
 
 public enum Operator: String, Equatable, CustomStringConvertible {
@@ -88,7 +105,7 @@ public indirect enum ParameterDeclaration: CustomStringConvertible {
         case .parameter(let p):
             return p.short
         case .expression(let p):
-            return p.map { $0.short }.joined(separator: " ")
+            return "[\(p.map { $0.short }.joined(separator: " "))]"
         case .tag(let tag):
             return tag.name + "(" + tag.params.map { $0.short }.joined(separator: " ") + ")"
         }
@@ -194,5 +211,102 @@ public enum LeafToken: CustomStringConvertible, Equatable  {
         case .whitespace(let length):
             return "whitespace(\(length))"
         }
+    }
+}
+
+internal extension Array where Element == ParameterDeclaration {
+    // evaluate a flat array of Parameters ("Expression")
+    // returns true if the expression was reduced, false if
+    // not or if unreducable (eg, non-flat or no operands).
+    // Does not promise that the resulting Expression is valid.
+    // This is brute force and not very efficient.
+    @discardableResult mutating func evaluate() -> Bool {
+        // Expression with no operands can't be evaluated
+        var ops = operandCount()
+        guard ops > 0 else { return false }
+        // check that the last param isn't an op, this is not resolvable
+        // since there are no unary postfix options currently
+        guard last?.operator() == nil else { return false }
+        
+        // Priority:
+        // Unary: Not
+        // Binary Math: Mult/Div -> Plus/Minus
+        // Binary Boolean: >/>=/<=/< -> !=/== -> &&/||
+        let precedenceMap: [(check: ((Operator) -> Bool) , binary: Bool)]
+        precedenceMap = [
+            (check: { $0 == .not } , binary: false), // unaryNot
+            (check: { $0 == .multiply || $0 == .divide } , binary: true), // Mult/Div
+            (check: { $0 == .plus || $0 == .minus } , binary: true), // Plus/Minus
+            (check: { $0 == .greaterThan || $0 == .greaterThanOrEquals } , binary: true), // >, >=
+            (check: { $0 == .lessThan || $0 == .lessThanOrEquals } , binary: true), // <, <=
+            (check: { $0 == .equals || $0 == .notEquals } , binary: true), // !, !=
+            (check: { $0 == .and || $0 == .or } , binary: true), // &&, ||
+        ]
+            
+        groupOps: for map in precedenceMap {
+            while let i = findLastOpWhere(map.check) {
+                if map.binary { wrapBinaryOp(i)}
+                else { wrapUnaryNot(i) }
+                // Some expression could not be wrapped - probably malformed syntax
+                if ops == operandCount() { return false } else { ops -= 1 }
+                if operandCount() == 0 { break groupOps }
+            }
+        }
+        
+        flatten()
+        return ops > 1 ? true : false
+    }
+    
+    mutating func flatten() {
+        while count == 1 {
+            if case .expression(let e) = self.first! {
+                self.removeAll()
+                self.append(contentsOf: e)
+            } else { return }
+        }
+        return
+    }
+    
+    fileprivate mutating func wrapUnaryNot(_ i: Int) {
+        let rhs = remove(at: i + 1)
+        if case .parameter(let p) = rhs, case .keyword(let key) = p, key.isBooleanValued {
+            self[i] = .parameter(.keyword(Keyword(rawValue: String(!key.booleanValue!))!))
+        } else {
+            self[i] = .expression([self[i],rhs])
+        }
+    }
+    
+    // could be smarter and check param types beyond verifying non-op but we're lazy here
+    fileprivate mutating func wrapBinaryOp(_ i: Int) {
+        // can't wrap unless there's a lhs and rhs
+        guard self.indices.contains(i-1),self.indices.contains(i+1) else { return }
+        let lhs = self[i-1]
+        let rhs = self[i+1]
+        // can't wrap if lhs or rhs is an operator
+        if case .parameter(let p) = lhs, case .operator = p { return }
+        if case .parameter(let p) = rhs, case .operator = p { return }
+        self[i] = .expression([lhs, self[i], rhs])
+        self.remove(at:i+1)
+        self.remove(at:i-1)       
+    }
+
+    // Helper functions
+    func operandCount() -> Int { return reduceOpWhere { _ in true } }
+    func unaryOps() -> Int { return reduceOpWhere { $0.isUnaryPrefix } }
+    func binaryOps() -> Int { return reduceOpWhere { $0.isBinary } }
+    func reduceOpWhere(_ check: (Operator) -> Bool) -> Int {
+        return self.reduce(0, { count, pD  in
+            if let op = pD.operator() {
+                return check(op) ? count + 1 : count
+            }
+            return count
+        })
+    }
+    
+    func findLastOpWhere(_ check: (Operator) -> Bool) -> Int? {
+        for (index, pD) in self.enumerated().reversed() {
+            if let op = pD.operator(), check(op) { return index }
+        }
+        return nil
     }
 }

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -36,7 +36,7 @@ final class ParserTests: XCTestCase {
         
         let expectation = """
         conditional:
-          if(expression(lowercase(first(name == "admin")) == "welcome")):
+          if(expression(lowercase(first([name == "admin"])) == "welcome")):
             raw("\\nfoo\\n")
         """
         
@@ -1080,7 +1080,7 @@ final class LeafKitTests: XCTestCase {
         
             let page = try! renderer.render(path: "page", context: [:]).wait()
             XCTAssertEqual(page.string, expected)
-    }    
+    }
 }
 
 struct TestFiles: LeafFiles {

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -448,6 +448,47 @@ final class LexerTests: XCTestCase {
         XCTAssertEqual(output, expectation)
     }
     
+    func testNoWhitespace() throws {
+        let input1 = "#if(!one||!two)"
+        let input2 = "#if(!one || !two)"
+        let input3 = "#if(! one||! two)"
+        let input4 = "#if(! one || ! two)"
+
+        let output1 = try lex(input1).map { $0.description + "\n" } .reduce("", +)
+        let output2 = try lex(input2).map { $0.description + "\n" } .reduce("", +)
+        let output3 = try lex(input3).map { $0.description + "\n" } .reduce("", +)
+        let output4 = try lex(input4).map { $0.description + "\n" } .reduce("", +)
+        XCTAssertEqual(output1, output2)
+        XCTAssertEqual(output2, output3)
+        XCTAssertEqual(output3, output4)
+    }
+    
+    
+    // Base2/8/10/16 lexing for Int constants, Base10/16 for Double
+    func testNonDecimals() throws {
+        let input = "#(0b0101010 0o052 42 0_042 0x02A 0b0101010.0 0o052.0 42.0 0_042.0 0x02A.0)"
+        let expectation = """
+        tagIndicator
+        tag(name: "")
+        parametersStart
+        param(constant(42))
+        param(constant(42))
+        param(constant(42))
+        param(constant(42))
+        param(constant(42))
+        param(variable(0b0101010.0))
+        param(variable(0o052.0))
+        param(constant(42.0))
+        param(constant(42.0))
+        param(constant(42.0))
+        parametersEnd
+
+        """
+
+        let output = try lex(input).map { $0.description + "\n" } .reduce("", +)
+        XCTAssertEqual(output, expectation)
+    }
+    
     /*
      // TODO:
      

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 
 final class LeafTests: XCTestCase {
+    
     // currently not supported.. discussion ongoing
     func _testInterpolated() throws {
         let template = """
@@ -195,69 +196,54 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template, ["namelist": [.string("Tanner")]]), expectedName)
         try XCTAssertEqual(render(template), expectedNoName)
     }
-//
-//    func testEscapeExtraneousBody() throws {
-//        let template = """
-//        extension #("User") \\{
-//
-//        }
-//        """
-//        let expected = """
-//        extension User {
-//
-//        }
-//        """
-//        try XCTAssertEqual(renderer.testRender(template, .null), expected)
-//    }
-//
-//
-//    func testEscapeTag() throws {
-//        let template = """
-//        #("foo") \\#("bar")
-//        """
-//        let expected = """
-//        foo #("bar")
-//        """
-//        try XCTAssertEqual(renderer.testRender(template, .null), expected)
-//    }
-//
-//    func testCount() throws {
-//        let template = """
-//        count: #count(array)
-//        """
-//        let expected = """
-//        count: 4
-//        """
-//        let context = TemplateData.dictionary(["array": .array([.null, .null, .null, .null])])
-//        try XCTAssertEqual(renderer.testRender(template, context), expected)
-//    }
-//
-//    func testNestedSet() throws {
-//        let template = """
-//        #if(a){#set("title"){A}}title: #get(title)
-//        """
-//        let expected = """
-//        title: A
-//        """
-//
-//        let context = TemplateData.dictionary(["a": .bool(true)])
-//        try XCTAssertEqual(renderer.testRender(template, context), expected)
-//    }
-//
-//    func testDateFormat() throws {
-//        let template = """
-//        Date: #date(foo, "yyyy-MM-dd")
-//        """
-//
-//        let expected = """
-//        Date: 1970-01-16
-//        """
-//
-//        let context = TemplateData.dictionary(["foo": .double(1_337_000)])
-//        try XCTAssertEqual(renderer.testRender(template, context), expected)
-//
-//    }
-//
+
+//    func testEscapeExtraneousBody()... removed as obviated by syntax change
+
+    func testEscapeTag() throws {
+        let template = """
+        #("foo") \\#("bar")
+        """
+        let expected = """
+        foo #("bar")
+        """
+        try XCTAssertEqual(render(template, [:]), expected)
+    }
+    
+    // TODO: Reimplement #count
+    func _testCount() throws {
+        let template = """
+        count: #count(array)
+        """
+        let expected = """
+        count: 4
+        """
+        try XCTAssertEqual(render(template, ["array": ["","","",""]]), expected)
+    }
+    
+    // TODO: Are set/get totally deprecated?
+    func _testNestedSet() throws {
+        let template = """
+        #if(a){#set("title"){A}}title: #get(title)
+        """
+        let expected = """
+        title: A
+        """
+        try XCTAssertEqual(render(template, ["a": true]), expected)
+    }
+
+    // TODO: Reimplement #date
+    func _testDateFormat() throws {
+        let template = """
+        Date: #date(foo, "yyyy-MM-dd")
+        """
+
+        let expected = """
+        Date: 1970-01-16
+        """
+        try XCTAssertEqual(render(template, ["foo": 1_337_000]), expected)
+
+    }
+
 //    func testEmptyForLoop() throws {
 //        let template = """
 //        #for(category in categories) {
@@ -277,7 +263,7 @@ final class LeafTests: XCTestCase {
 //
 //        let context = Context(categories: [])
 //        let data = try TemplateDataEncoder().testEncode(context)
-//        try XCTAssertEqual(renderer.testRender(template, data), expected)
+//        try XCTAssertEqual(render(template, data), expected)
 //
 //    }
 //
@@ -295,76 +281,60 @@ final class LeafTests: XCTestCase {
 //
 //        let context = Stuff(title: "foo")
 //        let data = try TemplateDataEncoder().testEncode(context)
-//        try XCTAssertEqual(renderer.testRender(template, data), expected)
+//        try XCTAssertEqual(render(template, data), expected)
 //    }
-//
-//    func testInvalidForSyntax() throws {
-//        let data = try TemplateDataEncoder().testEncode(["names": ["foo"]])
-//        do {
-//            _ = try renderer.testRender("#for( name in names) {}", data)
-//            XCTFail("Whitespace not allowed here")
-//        } catch {
-//            XCTAssert("\(error)".contains("space not allowed"))
-//        }
-//
-//        do {
-//            _ = try renderer.testRender("#for(name in names ) {}", data)
-//            XCTFail("Whitespace not allowed here")
-//        } catch {
-//            XCTAssert("\(error)".contains("space not allowed"))
-//        }
-//
-//        do {
-//            _ = try renderer.testRender("#for( name in names ) {}", data)
-//            XCTFail("Whitespace not allowed here")
-//        } catch {
-//            XCTAssert("\(error)".contains("space not allowed"))
-//        }
-//
-//        do {
-//            _ = try renderer.testRender("#for(name in names) {}", data)
-//        } catch {
-//            XCTFail("\(error)")
-//        }
-//    }
-//
-//    func testTemplating() throws {
-//        let home = """
-//        #set("title", "Home")#set("body"){<p>#(foo)</p>}#embed("base")
-//        """
-//        let expected = """
-//        <title>Home</title>
-//        <body><p>bar</p></body>
-//
-//        """
-//        renderer.astCache = ASTCache()
-//        defer { renderer.astCache = nil }
-//        let data = try TemplateDataEncoder().testEncode(["foo": "bar"])
-//        try XCTAssertEqual(renderer.testRender(home, data), expected)
-//        try XCTAssertEqual(renderer.testRender(home, data), expected)
-//    }
-//
-//    // https://github.com/vapor/leaf/issues/96
-//    func testGH96() throws {
-//        let template = """
-//        #for(name in names) {
-//            #(name): index=#(index) last=#(isLast) first=#(isFirst)
-//        }
-//        """
-//        let expected = """
-//
-//            tanner: index=0 last=false first=true
-//
-//            ziz: index=1 last=false first=false
-//
-//            vapor: index=2 last=true first=false
-//
-//        """
-//        let data = try TemplateDataEncoder().testEncode([
-//            "names": ["tanner", "ziz", "vapor"]
-//            ])
-//        try XCTAssertEqual(renderer.testRender(template, data), expected)
-//    }
+
+    // TODO: WHY is whitespace not allowed here?!?
+    func _testInvalidForSyntax() throws {
+        let data: [String: LeafData] = ["names": LeafData(arrayLiteral: "foo")]
+        do {
+            _ = try render("#for( name in names):Hi#endfor", data)
+            XCTFail("Whitespace not allowed here")
+        } catch {
+            XCTAssert("\(error)".contains("space not allowed"))
+        }
+
+        do {
+            _ = try render("#for(name in names ):Hi#endfor", data)
+            XCTFail("Whitespace not allowed here")
+        } catch {
+            XCTAssert("\(error)".contains("space not allowed"))
+        }
+
+        do {
+            _ = try render("#for( name in names ):Hi#endfor", data)
+            XCTFail("Whitespace not allowed here")
+        } catch {
+            XCTAssert("\(error)".contains("space not allowed"))
+        }
+
+        do {
+            _ = try render("#for(name in names):Hi#endfor", data)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+//    func testTemplating()... * Removed as obviated by newer LeafCache tests
+
+    // https://github.com/vapor/leaf/issues/96
+    func testGH96() throws {
+        let template = """
+        #for(name in names):
+            #(name): index=#(index) last=#(isLast) first=#(isFirst)
+        #endfor
+        """
+        let expected = """
+
+            tanner: index=0 last=false first=true
+
+            ziz: index=1 last=false first=false
+
+            vapor: index=2 last=true first=false
+
+        """
+        try XCTAssertEqual(render(template, ["names": ["tanner", "ziz", "vapor"]]), expected)
+    }
     
     func testLoopIndices() throws {
         let template = """
@@ -431,100 +401,91 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template, ["isFirst": true]), expected)
     }
     
-//
-//    // https://github.com/vapor/leaf/issues/99
-//    func testGH99() throws {
-//        let template = """
-//        Hi #(first) #(last)
-//        """
-//        let expected = """
-//        Hi Foo Bar
-//        """
-//        let data = try TemplateDataEncoder().testEncode([
-//            "first": "Foo", "last": "Bar"
-//            ])
-//        try XCTAssertEqual(renderer.testRender(template, data), expected)
-//    }
-//
-//    // https://github.com/vapor/leaf/issues/101
-//    func testGH101() throws {
-//        let template = """
-//        #for(foo in foos){#(index+1):#(foo)}
-//        """
-//        let expected = "1:A2:B3:C"
-//        let data = try TemplateDataEncoder().testEncode([
-//            "foos": ["A", "B", "C"]
-//            ])
-//        try XCTAssertEqual(renderer.testRender(template, data), expected)
-//    }
-//
-//    // https://github.com/vapor/leaf/issues/105
-//    func testGH105() throws {
-//        do {
-//            let template = """
-//            #if(1 + 1 == 2) {hi}
-//            """
-//            let expected = "hi"
-//            let data = try TemplateDataEncoder().testEncode(["a": "a"])
-//            try XCTAssertEqual(renderer.testRender(template, data), expected)
-//        }
-//        do {
-//            let template = """
-//            #if(2 == 1 + 1) {hi}
-//            """
-//            let expected = "hi"
-//            let data = try TemplateDataEncoder().testEncode(["a": "a"])
-//            try XCTAssertEqual(renderer.testRender(template, data), expected)
-//        }
-//        do {
-//            let template = """
-//            #if(1 == 1 + 1 || 1 == 2 - 1) {hi}
-//            """
-//            let expected = "hi"
-//            let data = try TemplateDataEncoder().testEncode(["a": "a"])
-//            try XCTAssertEqual(renderer.testRender(template, data), expected)
-//        }
-//    }
-//
-//    // https://github.com/vapor/leaf/issues/127
-//    func testGH127Inline() throws {
-//        do {
-//            let template = """
-//            <html>
-//            <head>
-//            <title></title>#// Translate all copy!!!!!
-//            <style>
-//            """
-//            let expected = """
-//            <html>
-//            <head>
-//            <title></title>
-//            <style>
-//            """
-//            let data = try TemplateDataEncoder().testEncode(["a": "a"])
-//            try XCTAssertEqual(renderer.testRender(template, data), expected)
-//        }
-//    }
-//
-//    func testGH127SingleLine() throws {
-//        do {
-//            let template = """
-//            <html>
-//            <head>
-//            <title></title>
-//            #// Translate all copy!!!!!
-//            <style>
-//            """
-//            let expected = """
-//            <html>
-//            <head>
-//            <title></title>
-//            <style>
-//            """
-//            let data = try TemplateDataEncoder().testEncode(["a": "a"])
-//            try XCTAssertEqual(renderer.testRender(template, data), expected)
-//        }
-//    }
+
+    // https://github.com/vapor/leaf/issues/99
+    func testGH99() throws {
+        let template = """
+        Hi #(first) #(last)
+        """
+        let expected = """
+        Hi Foo Bar
+        """
+        try XCTAssertEqual(render(template, ["first": "Foo", "last": "Bar"]), expected)
+    }
+
+    // https://github.com/vapor/leaf/issues/101
+    func testGH101() throws {
+        let template = """
+        #for(foo in foos):#(index+1):#(foo)#endfor
+        """
+        let expected = "1:A2:B3:C"
+        try XCTAssertEqual(render(template, ["foos": ["A", "B", "C"]]), expected)
+    }
+
+    // https://github.com/vapor/leaf/issues/105
+    // FIXME: Parser is not resolving expressions
+    func _testGH105() throws {
+        do {
+            let template = """
+            #if(1 + 1 == 2):hi#endif
+            """
+            let expected = "hi"
+            try XCTAssertEqual(render(template, ["a": "a"]), expected)
+        }
+        do {
+            let template = """
+            #if(2 == 1 + 1):hi#endif
+            """
+            let expected = "hi"
+            try XCTAssertEqual(render(template, ["a": "a"]), expected)
+        }
+        do {
+            let template = """
+            #if(1 == 1 + 1 || 1 == 2 - 1):hi#endif
+            """
+            let expected = "hi"
+            try XCTAssertEqual(render(template, ["a": "a"]), expected)
+        }
+    }
+
+    // https://github.com/vapor/leaf/issues/127
+    // TODO: This commenting style is not used anymore but needs a replacement
+    func _testGH127Inline() throws {
+        do {
+            let template = """
+            <html>
+            <head>
+            <title></title>#// Translate all copy!!!!!
+            <style>
+            """
+            let expected = """
+            <html>
+            <head>
+            <title></title>
+            <style>
+            """
+            try XCTAssertEqual(render(template, ["a": "a"]), expected)
+        }
+    }
+    // TODO: This commenting style is not used anymore but needs a replacement
+    func _testGH127SingleLine() throws {
+        do {
+            let template = """
+            <html>
+            <head>
+            <title></title>
+            #// Translate all copy!!!!!
+            <style>
+            """
+            let expected = """
+            <html>
+            <head>
+            <title></title>
+            <style>
+            """
+            try XCTAssertEqual(render(template, ["a": "a"]), expected)
+        }
+    }
 }
 
 private func render(name: String = "test-render", _ template: String, _ context: [String: LeafData] = [:]) throws -> String {


### PR DESCRIPTION
### Major Changes ###
* Converts `LeafError` from Enum to source-reporting Struct
* Adjusts `Lexer` state change table for human clarity
* Adds `Lexer` robustness for parameters with no whitespace boundaries
* Adds `Lexer` parameter handling for bin/oct/hex constant `Int`s and hex `Double`s
* Adds `Lexer` internal methods for additional checking peek/pop sequences
* Makes `Parameter` depth a state variable in `Lexer` instead of an enum property
* Adjusts `Character` exts for additional granularity on token types
* Adjusts `Character` exts for start/body validity of token types
* Adds `Character` exts for bin/oct/hex numerics
* Adjusts `Parser` behavior to allow decaying `tagBodyIndicators` to `raw` when tag is known to have no body
* Adjusts `Parser` to allow replacing `Lexed` tokens when necessary for above
* Re-enables a number of `TestCase` functions from Leaf3 and adjusts for Leaf4 syntax

### Problems Solved ###
#### Better/clearer error handling properties ####
#### Much easier to follow state changes during lexing *In most cases* ####
`Parameter` processing is still complicated but other cases are clearly handled
#### Better `Parameter` handling with whitespace ####
EG, the varying inputs below all properly lex to the correct interpretation now. Before, the first three would inaccurately lex, and only the fourth would correctly lex the parameters to 
`operator(not) variable(one) operator(||) operator(not) variable(two)`
```
"#if(!one||!two)"
"#if(!one || !two)"
"#if(! one||! two)"
"#if(! one || ! two)"
```
#### Better handling of `tagBodyIndicator` ####
Previously syntax like `#(index):#(value)` would error because the colon was universally assumed to indicate the start of a body - now, cases where it's impossible for a tag to take a body (eg, anonymous functions for now) will mutate the tBI back to a raw colon. Next step to improving this is to make observers on tag and built-in control structures to allow parsing to inquire as to expected state (eg, a function may take two parameters and no body or one parameter and a body and both are acceptable)

#### Improved syntax options for constant numerics ####
You can specify bin/oct/hex `Int` and hex `Double` constants now in Swift-manner literals... eg
```
0b1111 // Constant Int
1_000_000 // Constant Int
0x0.50 // Constant Double
```
Why? Why *not*?