### PR TITLE
Looped conditional imports aren't resolved properly

### DIFF
--- a/Sources/LeafKit/LeafAST.swift
+++ b/Sources/LeafKit/LeafAST.swift
@@ -48,7 +48,7 @@ public struct LeafAST: Hashable {
                 case .extend(let e):
                     let key = e.key
                     if let insert = externals[key] {
-                        let inlined = e.extend(base: insert.ast)
+                        let inlined = insert.ast.resolvingImports(exports: e.exports)
                         ast.replaceSubrange(pos...pos, with: inlined)
                     } else {
                         unresolvedRefs.insert(key)

--- a/Sources/LeafKit/LeafLexer/LeafToken.swift
+++ b/Sources/LeafKit/LeafLexer/LeafToken.swift
@@ -296,6 +296,19 @@ internal extension Array where Element == ParameterDeclaration {
         }
         return nil
     }
+
+    func resolvingImports(exports: [String: Syntax.Export]) -> [ParameterDeclaration] {
+        map {
+            switch $0 {
+            case .parameter(_): return $0
+            case .expression(let params):
+                return .expression(params.resolvingImports(exports: exports))
+            case .tag(var customTag):
+                customTag.resolveImports(exports: exports)
+                return .tag(customTag)
+            }
+        }
+    }
     
     func describe(_ joinBy: String = " ") -> String {
         return self.map {$0.short }.joined(separator: joinBy)

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -1157,8 +1157,7 @@ final class LeafKitTests: XCTestCase {
             eventLoop: EmbeddedEventLoop()
         )
 
-        let page = try renderer.render(path: "base",
-                                       context: ["list": ["A", "B", "C"]]).wait()
+        let page = try renderer.render(path: "base", context: ["list": ["A", "B", "C"]]).wait()
         XCTAssertEqual(page.string, expected)
     }
 }

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -1160,6 +1160,51 @@ final class LeafKitTests: XCTestCase {
         let page = try renderer.render(path: "base", context: ["list": ["A", "B", "C"]]).wait()
         XCTAssertEqual(page.string, expected)
     }
+
+    func testMultipleLoopedConditionalImports() throws {
+        var test = TestFiles()
+        test.files["/base.leaf"] = """
+        #for(x in list1):
+        #extend("entry"):#export("something", "Whatever")#endextend
+        #endfor
+        #for(x in list2):
+        #extend("entry"):#export("something", "Something Else")#endextend
+        #endfor
+        """
+        test.files["/entry.leaf"] = """
+        #(x): #if(isFirst):#import("something")#else:Not First#endif
+        """
+
+        let expected = """
+
+        A: Whatever
+
+        B: Not First
+
+        C: Not First
+
+
+        A: Something Else
+
+        B: Not First
+
+        C: Not First
+
+        """
+
+        let renderer = LeafRenderer(
+            configuration: .init(rootDirectory: "/"),
+            cache: DefaultLeafCache(),
+            files: test,
+            eventLoop: EmbeddedEventLoop()
+        )
+
+        let page = try renderer.render(path: "base", context: [
+            "list1": ["A", "B", "C"],
+            "list2": ["A", "B", "C"],
+        ]).wait()
+        XCTAssertEqual(page.string, expected)
+    }
 }
 
 struct TestFiles: LeafFiles {


### PR DESCRIPTION
When using `#import` inside an `#if` that is nested inside a file that is embedded using `#extend`, the rendering fails since apparently the `#import` isn't resolved.

I've tried to find the cause and fix it myself, but wasn't able to understand the process in reasonable time. So I've at least added a (currently failing) test for it.

Resolves #57 