### PR TITLE
Improved #export/#import Behavior

### DIFF
--- a/Sources/LeafKit/LeafAST.swift
+++ b/Sources/LeafKit/LeafAST.swift
@@ -44,21 +44,30 @@ public struct LeafAST: Hashable {
 
         // inline provided externals
         while pos < ast.endIndex {
-            switch ast[pos] {
-                case .extend(let e):
-                    let key = e.key
-                    if let insert = externals[key] {
-                        let inlined = e.extend(base: insert.ast)
-                        ast.replaceSubrange(pos...pos, with: inlined)
-                    } else {
-                        unresolvedRefs.insert(key)
-                        pos = ast.index(after: pos)
-                    }
-                default:
-                    var new: Syntax? = nil
-                    unresolvedRefs.formUnion(ast[pos].inlineRefs(externals, &new))
-                    if let new = new { ast[pos] = new }
-                    pos = ast.index(after: pos)
+            // get desired externals for this Syntax - if none, continue
+            let wantedExts = ast[pos].externals()
+            if wantedExts.isEmpty {
+                pos = ast.index(after: pos)
+                continue
+            }
+            // see if we can provide any of them - if not, continue
+            let providedExts = externals.filter { wantedExts.contains($0.key) }
+            if providedExts.isEmpty {
+                unresolvedRefs.formUnion(wantedExts)
+                pos = ast.index(after: pos)
+                continue
+            }
+            
+            // replace the original Syntax with the results of inlining, potentially 1...n
+            let replacementSyntax = ast[pos].inlineRefs(providedExts, [:])
+            ast.replaceSubrange(pos...pos, with: replacementSyntax)
+            // any returned new inlined syntaxes can't be further resolved at this point
+            // but we need to add their unresolvable references to the global set
+            var offset = replacementSyntax.startIndex
+            while offset < replacementSyntax.endIndex {
+                unresolvedRefs.formUnion(ast[pos].externals())
+                offset = replacementSyntax.index(after: offset)
+                pos = ast.index(after: pos)
             }
         }
 

--- a/Sources/LeafKit/LeafLexer/LeafToken.swift
+++ b/Sources/LeafKit/LeafLexer/LeafToken.swift
@@ -203,7 +203,7 @@ public indirect enum ParameterDeclaration: CustomStringConvertible {
         }
     }
     
-    func imports() -> Set<String> {
+    internal func imports() -> Set<String> {
         switch self {
             case .parameter(_): return .init()
             case .expression(let e): return e.imports()
@@ -212,12 +212,12 @@ public indirect enum ParameterDeclaration: CustomStringConvertible {
                 guard let parameter = t.params.first,
                       case .parameter(let p) = parameter,
                       case .stringLiteral(let key) = p,
-                      key.count > 0 else { return .init() }
+                      !key.isEmpty else { return .init() }
                 return .init(arrayLiteral: key)
         }
     }
     
-    func inlineImports(_ imports: [String : Syntax.Export]) -> ParameterDeclaration {
+    internal func inlineImports(_ imports: [String : Syntax.Export]) -> ParameterDeclaration {
         switch self {
             case .parameter(_): return self
             case .tag(let t):
@@ -227,7 +227,6 @@ public indirect enum ParameterDeclaration: CustomStringConvertible {
                 guard let parameter = t.params.first,
                       case .parameter(let p) = parameter,
                       case .stringLiteral(let key) = p,
-                      key.count > 0,
                       let export = imports[key]?.body.first,
                       case .expression(let exp) = export,
                       exp.count == 1,

--- a/Sources/LeafKit/LeafParser/LeafParser.swift
+++ b/Sources/LeafKit/LeafParser/LeafParser.swift
@@ -205,8 +205,7 @@ struct LeafParser {
                     try tail.attach(new)
                     switch aW {
                         case .none:
-                            finished.removeLast()
-                            finished.append(.conditional(tail))
+                            finished[finished.index(before: finished.endIndex)] = .conditional(tail)
                         case .some(_):
                             awaitingBody[awaitingBody.index(before: awaitingBody.endIndex)].body.removeLast()
                             awaitingBody[awaitingBody.index(before: awaitingBody.endIndex)].body.append(.conditional(tail))

--- a/Sources/LeafKit/LeafSerialize/ParameterResolver.swift
+++ b/Sources/LeafKit/LeafSerialize/ParameterResolver.swift
@@ -92,7 +92,9 @@ struct ParameterResolver {
 
     // #if(lowercase(first(name == "admin")) == "welcome")
     private func resolve(expression: [ParameterDeclaration]) throws -> LeafData {
-        if expression.count == 2 {
+        if expression.count == 1 {
+            return try resolve(expression[0]).result
+        } else if expression.count == 2 {
             if let lho = expression[0].operator() {
                 let rhs = try resolve(expression[1]).result
                 return try resolve(op: lho, rhs: rhs)

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -19,7 +19,7 @@ public enum ConditionalSyntax {
     case `elseif`([ParameterDeclaration])
     case `else`
     
-    func imports() -> Set<String> {
+    internal func imports() -> Set<String> {
         switch self {
             case .if(let pDA), .elseif(let pDA):
                 var imports = Set<String>()
@@ -29,7 +29,7 @@ public enum ConditionalSyntax {
         }
     }
     
-    func inlineImports(_ imports: [String : Syntax.Export]) -> ConditionalSyntax {
+    internal func inlineImports(_ imports: [String : Syntax.Export]) -> ConditionalSyntax {
         switch self {
             case .else: return self
             case .if(let pDA): return .if(pDA.inlineImports(imports))
@@ -37,7 +37,7 @@ public enum ConditionalSyntax {
         }
     }
     
-    func expression() -> [ParameterDeclaration] {
+    internal func expression() -> [ParameterDeclaration] {
         switch self {
             case .else: return [.parameter(.keyword(.true))]
             case .elseif(let e): return e
@@ -71,7 +71,7 @@ public enum ConditionalSyntax {
 
 // temporary addition
 extension Syntax: BodiedSyntax  {
-    func externals() -> Set<String> {
+    internal func externals() -> Set<String> {
         switch self {
             case .conditional(let bS as BodiedSyntax),
                  .custom(let bS as BodiedSyntax),
@@ -82,7 +82,7 @@ extension Syntax: BodiedSyntax  {
         }
     }
     
-    func imports() -> Set<String> {
+    internal func imports() -> Set<String> {
         switch self {
             case .import(let i): return .init(arrayLiteral: i.key)
             case .conditional(let bS as BodiedSyntax),
@@ -96,7 +96,7 @@ extension Syntax: BodiedSyntax  {
         }
     }
     
-    func inlineRefs(_ externals: [String: LeafAST], _ imports: [String: Export]) -> [Syntax] {
+    internal func inlineRefs(_ externals: [String: LeafAST], _ imports: [String: Export]) -> [Syntax] {
         var result = [Syntax]()
         switch self {
             case .import(let im):
@@ -129,19 +129,19 @@ internal protocol BodiedSyntax {
 }
 
 extension Array: BodiedSyntax where Element == Syntax {
-    func externals() -> Set<String> {
+    internal func externals() -> Set<String> {
         var result = Set<String>()
         _ = self.map { result.formUnion( $0.externals()) }
         return result
     }
     
-    func imports() -> Set<String> {
+    internal func imports() -> Set<String> {
         var result = Set<String>()
         _ = self.map { result.formUnion( $0.imports() ) }
         return result
     }
 
-    func inlineRefs(_ externals: [String: LeafAST], _ imports: [String: Syntax.Export]) -> [Syntax] {
+    internal func inlineRefs(_ externals: [String: LeafAST], _ imports: [String: Syntax.Export]) -> [Syntax] {
         var result = [Syntax]()
         _ = self.map { result.append(contentsOf: $0.inlineRefs(externals, imports)) }
         return result

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -516,9 +516,9 @@ final class LeafTests: XCTestCase {
         """
 
         let syntax = """
-        [variable(index), operator(-), constant(5)]
-        [constant(10), operator(-), constant(5)]
-        [constant(10), operator(-), constant(5)]
+        expression[variable(index), operator(-), constant(5)]
+        expression[constant(10), operator(-), constant(5)]
+        expression[constant(10), operator(-), constant(5)]
         raw("-5")
         """
 
@@ -549,13 +549,13 @@ final class LeafTests: XCTestCase {
         """
 
         let syntax = """
-        [keyword(false), operator(&&), keyword(true)]
-        [keyword(false), operator(||), keyword(true)]
-        [keyword(true), operator(&&), keyword(true)]
-        [keyword(false), operator(||), keyword(false)]
-        [keyword(false), operator(||), keyword(true)]
+        expression[keyword(false), operator(&&), keyword(true)]
+        expression[keyword(false), operator(||), keyword(true)]
+        expression[keyword(true), operator(&&), keyword(true)]
+        expression[keyword(false), operator(||), keyword(false)]
+        expression[keyword(false), operator(||), keyword(true)]
         raw("true")
-        [expression(-5 + [10 - [[20 / 2] + [9 * -3]]]), operator(==), expression([90 / 3] + [2 * -10])]
+        expression[[-5 + [10 - [[20 / 2] + [9 * -3]]]], operator(==), [[90 / 3] + [2 * -10]]]
         """
 
         let expectation = """


### PR DESCRIPTION
This update provides significantly improved resolution of #export/#import.

### API Changes
The unbodied usage of `#export("exportkey", value)` now supports any acceptable single parameter as the exported value. Example uses:
```swift
// Exports context variable
#export("isAdmin", admin)
// Exports an expression
#export("specialKey", username == "tdotclare")
// Exports a custom tag call
#export("baseURL", baseURL()) 
```
`#import` can now be used inside parameters, allowing behavior like:
```swift
#if(import("showSidebar")): <div id="sidebar"><div>  #endif
```
### Observable Behavior Changes/Fixes
* Fixes Issue #57 - `#import` syntaxes are now correctly replaced when nested inside other objects like loops

### Internal Changes
* `Syntax.Conditional` is now a chained-block struct instead of linked classes
* Adds `BodiedSyntax` protocol to applicable `Syntax`es, replacing monolithic extensions
  * Publish & maintain external or import dependency sets for adherants
  * Provide `inlineRefs` methods to adherents to self-rebuild
* Smarter `LeafAST` resolution
* Provides applicable `import` capabilities to ParameterDescription and Parameter