### PR TITLE
Improved Rendering Performance

### DIFF
--- a/Sources/LeafKit/Deprecated.swift
+++ b/Sources/LeafKit/Deprecated.swift
@@ -55,7 +55,3 @@ extension LeafSource {
 /// Deprecated in Leaf-Kit 1.0.0rc-1.11
 @available(*, deprecated, renamed: "LeafSource")
 typealias LeafFiles = LeafSource
-
-/// Deprecated in Leaf-Kit 1.0.0rc-1.11
-@available(*, deprecated, message: "Update LeafCache Implementation")
-public typealias ResolvedDocument = LeafAST

--- a/Sources/LeafKit/LeafAST.swift
+++ b/Sources/LeafKit/LeafAST.swift
@@ -2,7 +2,7 @@
 // MARK: -
 
 
-/// <#Description#>
+/// `LeafAST` represents a "compiled," grammatically valid Leaf template (which may or may not be fully resolvable or erroring)
 public struct LeafAST: Hashable {
     // MARK: - Public
     

--- a/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
+++ b/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
@@ -4,7 +4,7 @@
 
 import NIOConcurrencyHelpers
 
-public final class DefaultLeafCache: LeafCache {
+public final class DefaultLeafCache: BlockingLeafCache {
     // MARK: - Public - `LeafCache` Protocol Conformance
     
     /// Global setting for enabling or disabling the cache
@@ -86,4 +86,12 @@ public final class DefaultLeafCache: LeafCache {
     
     let lock: Lock
     var cache: [String: LeafAST]
+    
+    /// Blocking file load behavior
+    func load(documentName: String) -> LeafAST? {
+        guard isEnabled == true else { return nil }
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.cache[documentName]
+    }
 }

--- a/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
+++ b/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
@@ -4,7 +4,7 @@
 
 import NIOConcurrencyHelpers
 
-public final class DefaultLeafCache: BlockingLeafCache {
+public final class DefaultLeafCache: SynchronousLeafCache {
     // MARK: - Public - `LeafCache` Protocol Conformance
     
     /// Global setting for enabling or disabling the cache
@@ -45,7 +45,7 @@ public final class DefaultLeafCache: BlockingLeafCache {
     ///   - documentName: Name of the `LeafAST`  to try to return
     ///   - loop: `EventLoop` to return futures on
     /// - Returns: `EventLoopFuture<LeafAST?>` holding the `LeafAST` or nil if no matching result
-    public func load(
+    public func retrieve(
         documentName: String,
         on loop: EventLoop
     ) -> EventLoopFuture<LeafAST?> {
@@ -74,24 +74,18 @@ public final class DefaultLeafCache: BlockingLeafCache {
         return loop.makeSucceededFuture(true)
     }
     
-    // Deprecated by insert with remove: parameter - remove when possible
-    public func insert(
-        _ document: LeafAST,
-        on loop: EventLoop
-    ) -> EventLoopFuture<LeafAST> {
-        self.insert(document, on: loop, replace: false)
-    }
-    
     // MARK: - Internal Only
     
-    let lock: Lock
-    var cache: [String: LeafAST]
+    internal let lock: Lock
+    internal var cache: [String: LeafAST]
     
     /// Blocking file load behavior
-    func load(documentName: String) -> LeafAST? {
-        guard isEnabled == true else { return nil }
+    internal func retrieve(documentName: String) throws -> LeafAST? {
+        guard isEnabled == true else { throw LeafError(.cachingDisabled) }
         self.lock.lock()
         defer { self.lock.unlock() }
-        return self.cache[documentName]
+        let result = self.cache[documentName]
+        guard result != nil else { throw LeafError(.noValueForKey(documentName)) }
+        return result
     }
 }

--- a/Sources/LeafKit/LeafCache/LeafCache.swift
+++ b/Sources/LeafKit/LeafCache/LeafCache.swift
@@ -52,6 +52,14 @@ public protocol LeafCache {
     ) -> EventLoopFuture<ResolvedDocument>
 }
 
+/// A `LeafCache` that provides certain blocking methods for non-future access to the cache
+///
+/// Adherents *MUST* be thread-safe and *SHOULD NOT* be blocking simply to avoid futures -
+/// only adhere to this protocol if using futures is needless overhead
+internal protocol BlockingLeafCache: LeafCache {
+    func load(documentName: String) -> LeafAST?
+}
+
 // MARK: - LeafCache default implementations for older adherants
 extension LeafCache {
     /// default implementation of remove to avoid breaking custom LeafCache adopters

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -92,7 +92,8 @@ public final class LeafRenderer {
 
         // If cache provides blocking load, try to get a flat AST immediately
         if let blockingCache = cache as? BlockingLeafCache,
-           let cached = blockingCache.load(documentName: path) {
+           let cached = blockingCache.load(documentName: path),
+           cached.flat {
             do {
                 let buffer = try serialize(cached, context: context)
                 return eventLoop.makeSucceededFuture(buffer)

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -653,7 +653,7 @@ final class LeafKitTests: XCTestCase {
 
     func testCacheSpeedLinear() {
         self.measure {
-            self._testCacheSpeedLinear(templates: 10, iterations: 1_000_000)
+            self._testCacheSpeedLinear(templates: 10, iterations: 100)
         }
     }
 
@@ -679,7 +679,7 @@ final class LeafKitTests: XCTestCase {
     func testCacheSpeedRandom() {
         self.measure {
             // layer1 > layer2 > layer3
-            self._testCacheSpeedRandom(layer1: 100, layer2: 20, layer3: 10, iterations: 1_000_000)
+            self._testCacheSpeedRandom(layer1: 100, layer2: 20, layer3: 10, iterations: 130)
         }
     }
 

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -653,7 +653,7 @@ final class LeafKitTests: XCTestCase {
 
     func testCacheSpeedLinear() {
         self.measure {
-            self._testCacheSpeedLinear(templates: 10, iterations: 100)
+            self._testCacheSpeedLinear(templates: 10, iterations: 1_000_000)
         }
     }
 
@@ -679,7 +679,7 @@ final class LeafKitTests: XCTestCase {
     func testCacheSpeedRandom() {
         self.measure {
             // layer1 > layer2 > layer3
-            self._testCacheSpeedRandom(layer1: 100, layer2: 20, layer3: 10, iterations: 130)
+            self._testCacheSpeedRandom(layer1: 100, layer2: 20, layer3: 10, iterations: 1_000_000)
         }
     }
 


### PR DESCRIPTION
This release substantially improves the rendering performance of Leaf on typical calls where the template is fully resolved and cached.

### Performance Comparison
- Linear test - 10 flat templates, 1 million render calls against them
- Random test - 10 flat templates (layer 3), 20 templates referencing one of the flat templates (layer 2), 100 templates referencing two random layer 2 templates (layer 1). 1 million render calls against a random one of the 130 total templates.
- Each test was run 50 times on an 4GHz i7 Retina iMac

#### Linear
Branch | Min | Avg | Max | Avg Baseline | Avg CPU Time | CPU Baseline
--- | --- | --- | --- | --- | --- | ---
1.0.0rc-1.13 | 4.27s | 4.72s | 5.14s | 44.83% | 1m 14s | 40.72%
1.0.0rc-1.12 | 10.4s | 10.52s | 11.4s | 100% | 3m 1s | 100%

#### Random
Branch | Min | Avg | Max | Avg Baseline | Avg CPU Time | CPU Baseline
--- | --- | --- | --- | --- | --- | ---
1.0.0rc-1.13 | 4.43s | 4.82s | 5.17s | 49.9% | 1m 18s | 45.3%
1.0.0rc-1.12 | 9s | 9.66s | 10.61s | 100% | 2m 51s | 100%

*NOTE* this is purely a pipeline measurement - the templates used are lightweight and require near-zero time to serialize