### PR TITLE
Leaf4 Template Commenting & Multiline Parameters

### DIFF
--- a/Sources/LeafKit/LeafLexer/LeafLexer.swift
+++ b/Sources/LeafKit/LeafLexer/LeafLexer.swift
@@ -170,6 +170,7 @@ internal struct LeafLexer {
                 let comment = LeafToken.comment(content: lexRaw())
                 src.pop() // consume closing tagIndicatior
                 return comment
+            case .newLine: return .whitespace(length: 1)
             default: break
         }
 

--- a/Sources/LeafKit/LeafLexer/LeafToken.swift
+++ b/Sources/LeafKit/LeafLexer/LeafToken.swift
@@ -46,8 +46,11 @@ internal enum LeafToken: CustomStringConvertible, Equatable  {
     case parameter(Parameter)
     /// `)` -  Indicates the end of a tag's parameters
     case parametersEnd
-
-    /// To be removed if possible - avoid using
+    
+    /// A comment block inside `parameters` (`# A Comment #`) = .comment("A Comment")
+    case comment(content: String)
+    
+    /// Probably should be refactored to allow for interpolation
     case stringLiteral(String)
     /// To be removed if possible - avoid using
     case whitespace(length: Int)
@@ -75,6 +78,8 @@ internal enum LeafToken: CustomStringConvertible, Equatable  {
                 return "stringLiteral(\(string.debugDescription))"
             case .whitespace(let length):
                 return "whitespace(\(length))"
+            case .comment(_):
+                return "comment"
         }
     }
 }

--- a/Sources/LeafKit/LeafParser/LeafParser.swift
+++ b/Sources/LeafKit/LeafParser/LeafParser.swift
@@ -226,7 +226,7 @@ internal struct LeafParser {
                 case .parameterDelimiter:
                     pop()
                     dump()
-                case .whitespace, .comment(_):
+                case .whitespace, .comment:
                     pop()
                     continue
                 default:

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -30,13 +30,20 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(multilineTemplate), "foo\n\nbar")
     }
     
-    func testLeaf4Comment() throws {
+    func testCommentsAndParamLineSplit() throws {
         let template = """
         #("foo" # Foo is a stringLiteral #)
 
         #aTag("foo" # is the first parameter #, b # is a context variable #)
 
         #notAComment("# This is a literal string #")
+
+        #multipleParameters(param1,
+                            param2)
+
+        #(5 # you can do this #
+          +
+          5 # but I wouldn't #)
 
         #(#
             A multiline comment
@@ -47,6 +54,8 @@ final class LeafTests: XCTestCase {
         raw("foo")
         aTag(stringLiteral("foo"), variable(b))
         notAComment(stringLiteral("# This is a literal string #"))
+        multipleParameters(variable(param1), variable(param2))
+        expression[constant(5), operator(+), constant(5)]
         """
         
         let parsed = try parse(template)

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -29,6 +29,31 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template), "foo\nbar")
         try XCTAssertEqual(render(multilineTemplate), "foo\n\nbar")
     }
+    
+    func testLeaf4Comment() throws {
+        let template = """
+        #("foo" # Foo is a stringLiteral #)
+
+        #aTag("foo" # is the first parameter #, b # is a context variable #)
+
+        #notAComment("# This is a literal string #")
+
+        #(#
+            A multiline comment
+        #)
+        """
+        
+        let syntax = """
+        raw("foo")
+        aTag(stringLiteral("foo"), variable(b))
+        notAComment(stringLiteral("# This is a literal string #"))
+        """
+        
+        let parsed = try parse(template)
+            .compactMap { $0.description != "raw(\"\\n\\n\")" ? $0.description : nil }
+            .joined(separator: "\n")
+        XCTAssertEqual(parsed, syntax)
+    }
 
     // conversation ongoing
     func _testHashtag() throws {


### PR DESCRIPTION
This release adds template commenting and splitting tag parameters across lines.

### Commenting Format
* Comments can be located anywhere inside the parameters of a tag call, but not inside parameters themselves
* Comment blocks are opened and closed with the configured tagIndicator (`#` in normal/default situations)
* Comment blocks may contain any character but the tagIndicator (which may be escaped to include - `\#`)
* An anonymous tag can be used as a top-level comment, either as a single or multiline comment

Example; the following Leaf template:
```rust
#("foo" # is a stringLiteral #)

#aTag(1_000 # is a thousand #, "bar" # is also a parameter #)

#notAComment("# This is a literal string #")

#(# Anonymous tags are effectively both single line... #)

#(# 
... and multiline comments
#)
```
... is identical to:
```rust
#("foo")

#aTag(1_000, "bar")

#notAComment("# This is a literal string #")


```

### Multiline Parameters
For clarity, tag parameters may be split across lines.

Example:
```rust
#(5
  +
  5)

// is identical to

#(5 + 5)
```
And can be combined with comments:
```rust
#if(permitted(customer,   # Customer permissions #
              asset.acl   # Groups allowed #)):
    Hi #(customer.name)! You have access!
#endif
```

### Notes
This release closes #15