### PR TITLE
Add convenience methods to obscure some of the inner NIO workings

### DIFF
--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -602,6 +602,13 @@ final class LeafKitTests: XCTestCase {
         try group.syncShutdownGracefully()
     }
 
+    /// Tests that usage of the `LeafRenderer` convenience initializer compiles and renders a
+    /// simple test file correctly.
+    func testConvenienceRenderer() throws {
+        let renderer = LeafRenderer(rootDirectory: templateFolder)
+        XCTAssertEqual(try renderer.renderSync(path: "test", context: [:]), "Leaf Template\n")
+    }
+
     func testRendererContext() throws {
         var test = TestFiles()
         test.files["/foo.leaf"] = "Hello #custom(name)"


### PR DESCRIPTION
In usage outside of Vapor, these methods will provide a much cleaner API and eliminate a lot of the boilerplate code needed to manage the NIO objects. Most of the implementation comes from the existing tests, this change mostly just provides that common usage pattern as a dedicated initializer.

Not sure if this is wanted, but figured I'd get an implementation out to see. This would certainly remove quite a bit of boilerplate code from a few simple projects I've been doing, and could be used down the road to simplify some of the existing tests as well, which is where this code was pulled from.