### PR TITLE
LeafConfiguration Encoding and Formatting Options

### DIFF
--- a/Sources/LeafKit/Exports.swift
+++ b/Sources/LeafKit/Exports.swift
@@ -9,7 +9,7 @@ extension Character {
     
     // FIXME: Make .tagIndicatore write-once
     /// Global setting of `tagIndicator` for Leaf-Kit - by default, `#`
-    public static var tagIndicator: Character = .octothorpe
+    public internal(set) static var tagIndicator: Character = .octothorpe
     
     // MARK: - LeafToken specific identities (Internal)
     

--- a/Sources/LeafKit/Exports.swift
+++ b/Sources/LeafKit/Exports.swift
@@ -7,7 +7,6 @@
 extension Character {
     // MARK: - Leaf-Kit specific static identities (Public)
     
-    // FIXME: Make .tagIndicatore write-once
     /// Global setting of `tagIndicator` for Leaf-Kit - by default, `#`
     public internal(set) static var tagIndicator: Character = .octothorpe
     

--- a/Sources/LeafKit/LeafConfiguration.swift
+++ b/Sources/LeafKit/LeafConfiguration.swift
@@ -1,0 +1,108 @@
+// MARK: Subject to change prior to 1.0.0 release
+// MARK: -
+
+import Foundation
+
+/// General configuration of Leaf
+/// - Sets the default View directory where templates will be looked for
+/// - Guards setting the global tagIndicator (default `#`).
+public struct LeafConfiguration {
+    
+    /// Initialize Leaf with the default tagIndicator `#`
+    /// - Parameter rootDirectory: Default directory where templates will be found
+    public init(rootDirectory: String) {
+        self.init(rootDirectory: rootDirectory, tagIndicator: .octothorpe)
+    }
+    
+    /// Initialize Leaf with a specific tagIndicator
+    /// - Parameter rootDirectory: Default directory where templates will be found
+    /// - Parameter tagIndicator: Unique tagIndicator - may only be set once.
+    public init(rootDirectory: String, tagIndicator: Character) {
+        if !Self.started {
+            Character.tagIndicator = tagIndicator
+            Self.started = true
+        }
+        self._rootDirectory = rootDirectory
+    }
+    
+    //
+    public var rootDirectory: String {
+        get { _rootDirectory }
+        set { if !Self.running { _rootDirectory = newValue } }
+    }
+
+    public static var encoding: String.Encoding {
+        get { _encoding }
+        set { if !Self.running { _encoding = newValue } }
+    }
+    
+    public static var boolFormatter: (Bool) -> String {
+        get { _boolFormatter }
+        set { if !Self.running { _boolFormatter = newValue } }
+    }
+    
+    public static var intFormatter: (Int) -> String {
+        get { _intFormatter }
+        set { if !Self.running { _intFormatter = newValue } }
+    }
+    
+    public static var doubleFormatter: (Double) -> String {
+        get { _doubleFormatter }
+        set { if !Self.running { _doubleFormatter = newValue } }
+    }
+    
+    public static var nilFormatter: () -> String {
+        get { _nilFormatter }
+        set { if !Self.running { _nilFormatter = newValue } }
+    }
+    
+    public static var voidFormatter: () -> String {
+        get { _voidFormatter }
+        set { if !Self.running { _voidFormatter = newValue } }
+    }
+    
+    public static var stringFormatter: (String) -> String {
+        get { _stringFormatter }
+        set { if !Self.running { _stringFormatter = newValue } }
+    }
+    
+    public static var arrayFormatter: ([String]) -> String {
+        get { _arrayFormatter }
+        set { if !Self.running { _arrayFormatter = newValue } }
+    }
+    
+    public static var dictFormatter: ([String: String]) -> String {
+        get { _dictFormatter }
+        set { if !Self.running { _dictFormatter = newValue } }
+    }
+    
+    public static var dataFormatter: (Data) -> String? {
+        get { _dataFormatter }
+        set { if !Self.running { _dataFormatter = newValue } }
+    }
+    
+    // MARK: - Internal/Private Only
+    internal var _rootDirectory: String
+    
+    internal static var _encoding: String.Encoding = .utf8
+    internal static var _boolFormatter: (Bool) -> String = { $0.description }
+    internal static var _intFormatter: (Int) -> String = { $0.description }
+    internal static var _doubleFormatter: (Double) -> String = { $0.description }
+    internal static var _nilFormatter: () -> String = { "" }
+    internal static var _voidFormatter: () -> String = { "" }
+    internal static var _stringFormatter: (String) -> String = { $0 }
+    internal static var _arrayFormatter: ([String]) -> String =
+        { "[\($0.map {" \"\($0)\" "}.joined(separator: ","))]" }
+    internal static var _dictFormatter: ([String: String]) -> String =
+        { "[\($0.map { "\($0): \"\($1)\"" }.joined(separator: ", "))]" }
+    internal static var _dataFormatter: (Data) -> String? =
+        { String(data: $0, encoding: Self._encoding) }
+    
+    
+    /// Convenience flag for write-once
+    private static var started = false
+    private static var running: Bool {
+        assert(Self.started, "LeafKit can only be configured prior to instantiating any LeafRenderer")
+        return Self.started
+    }
+}

--- a/Sources/LeafKit/LeafConfiguration.swift
+++ b/Sources/LeafKit/LeafConfiguration.swift
@@ -92,7 +92,7 @@ public struct LeafConfiguration {
     internal static var _voidFormatter: () -> String = { "" }
     internal static var _stringFormatter: (String) -> String = { $0 }
     internal static var _arrayFormatter: ([String]) -> String =
-        { "[\($0.map {" \"\($0)\" "}.joined(separator: ","))]" }
+        { "[\($0.map {"\"\($0)\""}.joined(separator: ", "))]" }
     internal static var _dictFormatter: ([String: String]) -> String =
         { "[\($0.map { "\($0): \"\($1)\"" }.joined(separator: ", "))]" }
     internal static var _dataFormatter: (Data) -> String? =

--- a/Sources/LeafKit/LeafData/LeafData.swift
+++ b/Sources/LeafKit/LeafData/LeafData.swift
@@ -3,231 +3,473 @@
 
 import Foundation
 
-/// Supported serializable data types.
-/// - note: This is different from types supported in the AST.
-public struct LeafData: LeafDataRepresentable, Equatable,
+//  LeafData is essentially a pseudo "Protocol" and limited set of Adherents
+
+/// `LeafData` is a "pseudo-protocol" wrapping the physically storable Swift data types
+/// Leaf can use directly
+/// - `(Bool, Int, Double, String, Array, Dictionary, Data)` are the inherent root types
+///     supported, all of which may also be representable as `Optional` values.
+/// - `NaturalType` presents these cases plus `Void` as a case for functional `LeafSymbols`
+/// - `nil` is creatable, but only within context of a root base type - eg, `.nil(.bool)` == `Bool?`
+public struct LeafData: CustomStringConvertible,
+                        Equatable,
                         ExpressibleByDictionaryLiteral,
                         ExpressibleByStringLiteral,
                         ExpressibleByIntegerLiteral,
                         ExpressibleByBooleanLiteral,
-                        ExpressibleByArrayLiteral {
-    // MARK: - Equatable Conformance
-
-    /// See `Equatable`.
-    public static func ==(lhs: LeafData, rhs: LeafData) -> Bool {
-        /// Fuzzy compare
-        if lhs.string != nil && lhs.string == rhs.string {
-            return true
-        } else if lhs.int != nil && lhs.int == rhs.int {
-            return true
-        } else if lhs.double != nil && lhs.double == rhs.double {
-            return true
-        } else if lhs.bool != nil && lhs.bool == rhs.bool {
-            return true
-        }
-
-        /// Strict compare
-        switch (lhs.storage, rhs.storage) {
-            case (.array(let a), .array(let b)):           return a == b
-            case (.dictionary(let a), .dictionary(let b)): return a == b
-            case (.bool(let a), .bool(let b)):             return a == b
-            case (.string(let a), .string(let b)):         return a == b
-            case (.int(let a), .int(let b)):               return a == b
-            case (.double(let a), .double(let b)):         return a == b
-            case (.data(let a), .data(let b)):             return a == b
-            case (.null, .null):                           return true
-            default:                                       return false
-        }
+                        ExpressibleByArrayLiteral,
+                        ExpressibleByFloatLiteral,
+                        ExpressibleByNilLiteral {
+    
+    /// The concrete instantiable object types for a `LeafData`
+    public enum NaturalType: Hashable {
+        case bool
+        case string
+        case int
+        case double
+        case data
+        case dictionary
+        case array
+        case void
     }
+    /// The case-self identity
+    public var celf: NaturalType { storage.concreteType! }
+    
+    /// Returns `true` if the data is `nil` or `void`.
+    public var isNil: Bool { storage.isNil }
+    /// Returns `true` if the data can hold other data - we don't consider `Optional` for this purpose
+    public var isContainer: Bool { [.array, .dictionary].contains(storage.concreteType) }
+    
+    /// Returns `true` if concrete object can be exactly or losslessly cast to a second type
+    /// - EG: `.nil ` -> `.string("")`, `.int(1)` ->  `.double(1.0)`,
+    ///      `.bool(true)` -> `.string("true")` are all one-way lossless conversions
+    /// - This does not imply it's not possible to *coerce* data - handle with `coerce(to:)`
+    ///   EG: `.string("")` -> `.nil`, `.string("1")` -> ` .bool(true)`
+    public func isCastable(to type: LeafData.NaturalType) -> Bool {
+        let conversion = _ConverterMap.symbols[storage.concreteType!, type]!
+        return conversion.is >= DataConvertible.castable
+    }
+    
+    /// Returns `true` if concrete object is potentially directly coercible to a second type in some way
+    /// - EG: `.array()` -> `.dictionary()` where array indices become keys
+    ///       or `.int(1)` -> `.bool(true)`
+    /// - This does *not* validate the data itself in coercion
+    public func isCoercible(to type: LeafData.NaturalType) -> Bool {
+        let conversion = _ConverterMap.symbols[storage.concreteType!, type]!
+        return conversion.is >= DataConvertible.coercible
+    }
+    
+    // MARK: - Equatable Conformance
+    public static func ==(lhs: LeafData, rhs: LeafData) -> Bool {
+        // Strict compare of invariant stored values; considers .nil & .void equal
+        guard !(lhs.storage == rhs.storage) else { return true }
+        // Lazy variant data should never be tested due to potential side-effects
+        guard lhs.invariant && rhs.invariant else { return false }
+        // Fuzzy comparison by string casting
+        guard lhs.isCastable(to: .string),
+              rhs.isCastable(to: .string),
+              let lhs = lhs.string, let rhs = rhs.string else { return false }
+        return lhs == rhs
+    }
+    
+    // MARK: - CustomStringConvertible
+    public var description: String { storage.description }
+    
+    /// Returns `true` if the object has a single uniform type
+    /// - Always true for invariant non-containers
+    /// - True or false for containers if determinable
+    /// - Nil if the object is variant lazy data, or invariant lazy producing a container, or a container holding such
+    public var hasUniformType: Bool? {
+        // Default case - anything that doesn't return a container
+        if !isContainer { return true }
+        // A container-returning lazy (unknowable) - specific test to avoid invariant check
+        if storage.isLazy && isContainer { return nil }
+        // A non-lazy container - somewhat expensive to check
+        if case .array(let a) = storage {
+            guard a.count > 1, let first = a.first?.concreteType else { return true }
+            return a.allSatisfy { $0.celf == first && $0.hasUniformType ?? false }
+        } else if case .dictionary(let d) = storage {
+            guard d.count > 1, let first = d.values.first?.concreteType else { return true }
+            return d.values.allSatisfy { $0.celf == first && $0.hasUniformType ?? false }
+        } else { return nil }
+    }
+    
+    /// Returns the uniform type of the object, or nil if it can't be determined/is a non-uniform container
+    public var uniformType: NaturalType? {
+        guard let determinable = hasUniformType, determinable else { return nil }
+        if !isContainer { return storage.concreteType }
+        if case .array(let a) = storage {
+            return a.isEmpty ? .void : a.first?.concreteType ?? nil
+        } else if case .dictionary(let d) = storage {
+            return d.values.isEmpty ? .void : d.values.first?.concreteType ?? nil
+        } else { return nil }
+    }
+    
+    // MARK: - Generic `LeafDataRepresentable` Initializer
+    public init(_ leafData: LeafDataRepresentable) { self = leafData.leafData }
 
     // MARK: - Static Initializer Conformances
-
     /// Creates a new `LeafData` from a `Bool`.
-    public static func bool(_ value: Bool) -> LeafData {
-        return .init(.bool(value))
+    public static func bool(_ value: Bool?) -> LeafData {
+        return value.map { LeafData(.bool($0)) } ?? LeafData(.optional(nil, .bool))
     }
-
     /// Creates a new `LeafData` from a `String`.
-    public static func string(_ value: String) -> LeafData {
-        return .init(.string(value))
+    public static func string(_ value: String?) -> LeafData {
+        return value.map { LeafData(.string($0)) } ?? LeafData(.optional(nil, .string))
     }
-
     /// Creates a new `LeafData` from am `Int`.
-    public static func int(_ value: Int) -> LeafData {
-        return .init(.int(value))
+    public static func int(_ value: Int?) -> LeafData {
+        return value.map { LeafData(.int($0)) } ?? LeafData(.optional(nil, .int))
     }
-
     /// Creates a new `LeafData` from a `Double`.
-    public static func double(_ value: Double) -> LeafData {
-        return .init(.double(value))
+    public static func double(_ value: Double?) -> LeafData {
+        return value.map { LeafData(.double($0)) } ?? LeafData(.optional(nil, .double))
     }
-
     /// Creates a new `LeafData` from `Data`.
-    public static func data(_ value: Data) -> LeafData {
-        return .init(.data(value))
+    public static func data(_ value: Data?) -> LeafData {
+        return value.map { LeafData(.data($0)) } ?? LeafData(.optional(nil, .data))
     }
-
     /// Creates a new `LeafData` from `[String: LeafData]`.
-    public static func dictionary(_ value: [String: LeafData]) -> LeafData {
-        return .init(.dictionary(value))
+    public static func dictionary(_ value: [String: LeafData]?) -> LeafData {
+        return value.map { LeafData(.dictionary($0)) } ?? LeafData(.optional(nil, .dictionary))
     }
-
     /// Creates a new `LeafData` from `[LeafData]`.
-    public static func array(_ value: [LeafData]) -> LeafData {
-        return .init(.array(value))
+    public static func array(_ value: [LeafData]?) -> LeafData {
+        return value.map { LeafData(.array($0)) } ?? LeafData(.optional(nil, .array))
     }
-
-    /// Creates a new `LeafData` from `() -> LeafData`.
-    public static func lazy(_ value: @escaping () -> LeafData) -> LeafData {
-        return .init(.lazy(value))
-    }
-
-    /// Creates a new null `LeafData`.
-    public static var null: LeafData {
-        return .init(.null)
+    /// Creates a new `LeafData` for `Optional<LeafData>`
+    public static func `nil`(_ type: LeafData.NaturalType) -> LeafData {
+        return .init(.optional(nil, type))
     }
 
     // MARK: - Literal Initializer Conformances
-
+    public init(nilLiteral: ()) { self = .trueNil }
+    public init(stringLiteral value: StringLiteralType) { self = value.leafData }
+    public init(integerLiteral value: IntegerLiteralType) { self = value.leafData }
+    public init(floatLiteral value: FloatLiteralType) { self = value.leafData }
+    public init(booleanLiteral value: BooleanLiteralType) { self = value.leafData }
+    public init(arrayLiteral elements: LeafData...) { self = .array(elements) }
     public init(dictionaryLiteral elements: (String, LeafData)...) {
         self = .dictionary(.init(uniqueKeysWithValues: elements))
-    }
-
-    public init(stringLiteral value: String) {
-        self = .string(value)
-    }
-
-    public init(integerLiteral value: Int) {
-        self = .int(value)
-    }
-
-    public init(booleanLiteral value: Bool) {
-        self = .bool(value)
-    }
-
-    public init(arrayLiteral elements: LeafData...) {
-        self = .array(elements)
     }
 
     // MARK: - Fuzzy Conversions from Storage to Types
 
     /// Attempts to convert to `Bool` or returns `nil`.
     public var bool: Bool? {
-        switch storage {
-            case .int(let i):
-                switch i {
-                    case 1:       return true
-                    case 0:       return false
-                    default:      return nil
-                }
-            case .double(let d):
-                switch d {
-                    case 1:       return true
-                    case 0:       return false
-                    default:      return nil
-                }
-            case .string(let s):  return Bool(s)
-            case .bool(let b):    return b
-            case .lazy(let lazy): return lazy().bool
-            default:              return nil
-        }
+        if case .bool(let b) = storage  { return b }
+        guard case .bool(let b) = convert(to: .bool).storage else { return nil }
+        return b
     }
 
     /// Attempts to convert to `String` or returns `nil`.
     public var string: String? {
-        switch storage {
-            case .bool(let bool):     return bool.description
-            case .double(let double): return double.description
-            case .int(let int):       return int.description
-            case .string(let s):      return s
-            case .data(let d):        return String(data: d, encoding: .utf8)
-            case .lazy(let lazy):     return lazy().string
-            default:                  return nil
-        }
+        if case .string(let s) = storage  { return s }
+        guard case .string(let s) = convert(to: .string).storage else { return nil }
+        return s
     }
 
     /// Attempts to convert to `Int` or returns `nil`.
     public var int: Int? {
-        switch storage {
-            case .int(let i):     return i
-            case .string(let s):  return Int(s)
-            case .lazy(let lazy): return lazy().int
-            default:              return nil
-        }
+        if case .int(let i) = storage  { return i }
+        guard case .int(let i) = convert(to: .int).storage else { return nil }
+        return i
     }
 
     /// Attempts to convert to `Double` or returns `nil`.
     public var double: Double? {
-        switch storage {
-            case .int(let i):     return Double(i)
-            case .double(let d):  return d
-            case .string(let s):  return Double(s)
-            case .lazy(let lazy): return lazy().double
-            default:              return nil
-        }
+        if case .double(let d) = storage  { return d }
+        guard case .double(let d) = convert(to: .double).storage else { return nil }
+        return d
     }
 
     /// Attempts to convert to `Data` or returns `nil`.
     public var data: Data? {
-        switch storage {
-            case .data(let d):            return d
-            case .string(let s):          return s.data(using: .utf8)
-            case .lazy(let lazy):         return lazy().data
-            case .int(let i):             return i.description.data(using: .utf8)
-            case .double(let d):          return d.description.data(using: .utf8)
-            case .dictionary:             return nil
-            case .bool:                   return nil
-            case .null:                   return nil
-            case .array(let arr):
-                var data = Data()
-                for i in arr {
-                    if i.isNull { break }
-                    let u = i.data
-                    guard u != nil else { return nil }
-                    data += u!
-                }
-                                          return data
-        }
+        if case .data(let d) = storage  { return d }
+        guard case .data(let d) = convert(to: .data).storage else { return nil }
+        return d
     }
 
     /// Attempts to convert to `[String: LeafData]` or returns `nil`.
     public var dictionary: [String: LeafData]? {
-        switch storage {
-            case .dictionary(let d): return d
-            default:                 return nil
-        }
+        if case .dictionary(let d) = storage  { return d }
+        guard case .dictionary(let d) = convert(to: .dictionary).storage else { return nil }
+        return d
     }
 
     /// Attempts to convert to `[LeafData]` or returns `nil`.
     public var array: [LeafData]? {
-        switch storage {
-            case .array(let a): return a
-            default:            return nil
-        }
-    }
-
-    /// Returns `true` if the data is `null`.
-    public var isNull: Bool {
-        switch storage {
-            case .null: return true
-            default: return false
-        }
-    }
-
-    // MARK: - LeafDataRepresentable Conformance
-
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return self
+        if case .array(let a) = storage  { return a }
+        guard case .array(let a) = convert(to: .array).storage else { return nil }
+        return a
     }
     
     // MARK: - Internal Only
     
     /// Actual storage.
-    internal var storage: LeafDataStorage
+    internal private(set) var storage: LeafDataStorage
     
-    /// Creates a new `LeafData`.
-    internal init(_ storage: LeafDataStorage) {
-        self.storage = storage
+    // MARK: - LeafSymbol Conformance
+    internal var resolved: Bool { storage.resolved }
+    internal var invariant: Bool { storage.invariant }
+    internal var symbols: Set<String> { .init() }
+    internal var isAtomic: Bool { true }
+    internal var isExpression: Bool { false }
+    internal var isConcrete: Bool { false }
+    internal var isAny: Bool { true }
+    internal var concreteType: NaturalType? { nil }
+    internal func softResolve() -> LeafData {
+        LeafData(storage.softResolve())
     }
+    internal func hardResolve() throws -> LeafData {
+        try storage.hardResolve() }
+    internal func serialize() throws -> String? {
+        try storage.serialize()
+    }
+    internal func serialize(buffer: inout ByteBuffer) throws {
+        try storage.serialize(buffer: &buffer)
+    }
+
+    /// Creates a new `LeafData`.
+    internal init(_ storage: LeafDataStorage) { self.storage = storage }
+    
+    /// Creates a new `LeafData` from `() -> LeafData` if possible or `nil` if not possible.
+    /// `returns` must specify a `NaturalType` that the function will return
+    internal static func lazy(_ lambda: @escaping () -> LeafData,
+                            returns type: LeafData.NaturalType,
+                            invariant sideEffects: Bool) throws -> LeafData {
+        LeafData(.lazy(f: lambda, returns: type, invariant: sideEffects))
+    }
+    
+    /// For convenience, `trueNil` is stored as `.optional(nil, .void)`
+    internal static var trueNil: LeafData { .init(.optional(nil, .void)) }
+    
+    internal func convert(to output: NaturalType, _ level: DataConvertible = .castable) -> LeafData {
+        guard celf != output else  { return self }
+        if case .lazy(let f,_,_) = self.storage { return f().convert(to: output, level) }
+        guard let input = storage.unwrap,
+              let conversion = _ConverterMap.symbols[input.concreteType!, output],
+              conversion.is >= level else { return nil }
+        switch input {
+            case .array(let any as Any),
+                 .bool(let any as Any),
+                 .data(let any as Any),
+                 .dictionary(let any as Any),
+                 .double(let any as Any),
+                 .int(let any as Any),
+                 .string(let any as Any): return conversion.via(any)
+            default: return nil
+        }
+    }
+}
+
+// MARK: - File Private
+/// We'll see about this
+
+
+
+fileprivate typealias Conversion = (is: DataConvertible, via: (Any) -> LeafData)
+
+fileprivate struct CelfKey: Hashable {
+    typealias T = LeafData.NaturalType
+    let from: T
+    let to: T
+    init(_ from: T, _ to: T) { self.from = from; self.to = to}
+    init(_ tuple: (from: T, to: T)) { from = tuple.from; to = tuple.to }
+}
+
+fileprivate extension Dictionary where Key == CelfKey {
+    typealias T = LeafData.NaturalType
+    subscript (key0: T, key1: T) -> Value? {
+        get {  return self[Key(key0, key1)] }
+        set {  self[Key(key0, key1)] = newValue }
+    }
+}
+
+// The data conversion map is purely used for casting or coercing between
+// the concrete types (Bool, Int, Double, String, Array, Dictionary, Data)
+// and will never attempt to handle optionals, which must *always* be unwrapped
+// to concrete types before being called.
+//
+// Converters are guaranteed to be provided non-nil input.
+// Failable converters must return LeafData.trueNil
+
+internal enum DataConvertible: Int, Equatable, Comparable {
+    /// Not implicitly convertible automatically
+    case ambiguous = 0
+    /// A coercioni with a clear meaning in one direction
+    case coercible = 1
+    /// A conversion with a well-defined bi-directional casting possibility
+    case castable = 2
+    /// An exact type match; identity
+    case identity = 3
+    
+    static func < (lhs: DataConvertible, rhs: DataConvertible) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+fileprivate enum _ConverterMap {
+    private static let c = LeafConfiguration.self
+    fileprivate static var symbols: Dictionary<CelfKey, Conversion> { [
+        // MARK: - .identity (Passthrough)
+        CelfKey(.array     , .array     ): (is: .identity, via: { .array($0 as? [LeafData]) }),
+        CelfKey(.bool      , .bool      ): (is: .identity, via: { .bool($0 as? Bool) }),
+        CelfKey(.data      , .data      ): (is: .identity, via: { .data($0 as? Data) }),
+        CelfKey(.dictionary, .dictionary): (is: .identity, via: { .dictionary($0 as? [String : LeafData]) }),
+        CelfKey(.double    , .double    ): (is: .identity, via: { .double($0 as? Double) }),
+        CelfKey(.int       , .int       ): (is: .identity, via: { .int($0 as? Int) }),
+        CelfKey(.string    , .string    ): (is: .identity, via: { .string($0 as? String) }),
+
+        // MARK: - .castable (Well-defined bi-directional conversions)
+                                        // Double in [0,1] == truthiness & value
+        CelfKey(.double  , .bool        ): (is: .castable, via: {
+            ($0 as? Double).map { [0.0, 1.0].contains($0) ? $0 == 1.0 : nil}?
+                .map { .bool($0) } ?? .trueNil
+        }),
+                                        // Int in [0,1] == truthiness & value
+        CelfKey(.int     , .bool        ): (is: .castable, via: {
+            ($0 as? Int).map { [0, 1].contains($0) ? $0 == 1 : nil }?
+                .map { .bool($0) } ?? .trueNil
+        }),
+                                        //  String == "true" || "false"
+        CelfKey(.string  , .bool        ): (is: .castable, via: {
+            ($0 as? String).map { Bool($0) }?.map { .bool($0) } ?? .trueNil
+        }),
+                                        // True = 1; False = 0
+        CelfKey(.bool    , .double      ): (is: .castable, via: {
+            ($0 as? Bool).map { $0 ? 1.0 : 0.0 }.map { .double($0) } ?? .trueNil
+        }),
+                                        // Direct conversion
+        CelfKey(.int     , .double      ): (is: .castable, via: {
+            ($0 as? Int).map { Double($0) }.map { .double($0) } ?? .trueNil
+        }),
+                                        // Using default string-init
+        CelfKey(.string  , .double      ): (is: .castable, via: {
+            ($0 as? String).map { Double($0) }?.map { .double($0) } ?? .trueNil
+        }),
+                                        // True = 1; False = 0
+        CelfKey(.bool    , .int         ): (is: .castable, via: {
+            ($0 as? Bool).map { $0 ? 1 : 0 }.map { .int($0) } ?? .trueNil
+        }),
+                                        // Base10 formatted Strings
+        CelfKey(.string  , .int         ): (is: .castable, via: {
+            ($0 as? String).map { Int($0) }?.map { .int($0) } ?? .trueNil
+        }),
+                                        // .description
+        CelfKey(.bool    , .string      ): (is: .castable, via: {
+            ($0 as? Bool).map { $0.description }.map { .string($0) } ?? .trueNil
+        }),
+                                        // Using configured encoding
+        CelfKey(.data    , .string      ): (is: .castable, via: {
+            ($0 as? Data).map { String(data: $0, encoding: c.encoding) }?
+                .map { .string($0) } ?? .trueNil
+        }),
+                                        // .description
+        CelfKey(.double  , .string      ): (is: .castable, via: {
+            ($0 as? Double).map { $0.description }.map { .string($0) } ?? .trueNil
+        }),
+                                        // .description
+        CelfKey(.int     , .string      ): (is: .castable, via: {
+            ($0 as? Int).map { $0.description }.map { .string($0) } ?? .trueNil
+        }),
+        
+        // MARK: - .coercible (One-direction defined conversion)
+
+                                          // Array.isEmpty == truthiness
+        CelfKey(.array      , .bool       ): (is: .coercible, via: {
+            ($0 as? [LeafData]).map { $0.isEmpty }.map { .bool($0) } ?? .trueNil
+        }),
+                                          // Data.isEmpty == truthiness
+        CelfKey(.data       , .bool       ): (is: .coercible, via: {
+            ($0 as? Data).map { $0.isEmpty }.map { .bool($0) } ?? .trueNil
+        }),
+                                          // Dictionary.isEmpty == truthiness
+        CelfKey(.dictionary , .bool       ): (is: .coercible, via: {
+            ($0 as? [String: LeafData]).map { $0.isEmpty }.map { .bool($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.array      , .data       ): (is: .coercible, via: {
+            ($0 as? [LeafData]).map {
+                try? LeafDataStorage.array($0).serialize()?.data(using: c.encoding)
+            }?.map { .data($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.bool       , .data       ): (is: .coercible, via: {
+            ($0 as? Bool).map { c.boolFormatter($0).data(using: c.encoding) }?
+                .map { .data($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.dictionary , .data       ): (is: .coercible, via: {
+            ($0 as? [String: LeafData]).map {
+                try? LeafDataStorage.dictionary($0).serialize()?.data(using: c.encoding)
+            }?.map { .data($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.double     , .data       ): (is: .coercible, via: {
+            ($0 as? Double).map {
+                c.doubleFormatter($0)
+                    .data(using: c.encoding)
+                }?.map { .data($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.int        , .data       ): (is: .coercible, via: {
+            ($0 as? Int).map { c.intFormatter($0)
+                .data(using: c.encoding)
+            }?.map { .data($0) } ?? .trueNil
+        }),
+                                          // Use the configured formatter
+        CelfKey(.string     , .data       ): (is: .coercible, via: {
+            ($0 as? String).map { c.stringFormatter($0)
+                .data(using: c.encoding)
+            }?.map { .data($0) } ?? .trueNil
+        }),
+                                          // Schoolbook rounding
+        CelfKey(.double     , .int        ): (is: .coercible, via: {
+            ($0 as? Double).map { Int(exactly: $0.rounded()) }?.map { .int($0) } ?? .trueNil
+        }),
+        
+        // FIXME: Questionable coercion possibilities - Currently disabled
+        
+                                          // Transform with array indices as keys
+        CelfKey(.array      , .dictionary ): (is: .ambiguous, via: {
+            ($0 as? [LeafData]).map {
+                Dictionary(uniqueKeysWithValues: $0.enumerated().map {
+                                                  (String($0), $1) }) }
+                .map { .dictionary($0) } ?? .trueNil
+        }),
+                                          // Conversion using the formatter
+        CelfKey(.array      , .string     ): (is: .ambiguous, via: {
+            ($0 as? [LeafData]).map {
+                let stringified: String? = try? LeafData.array($0).serialize()
+                return .string(stringified)
+            } ?? .trueNil
+        }),
+                                          // Conversion using the formatter
+        CelfKey(.dictionary , .string     ): (is: .ambiguous, via: {
+            ($0 as? [String: LeafData]).map {
+        let stringified: String? = try? LeafData.dictionary($0).serialize()
+                return .string(stringified)
+            } ?? .trueNil
+        }),
+
+        // MARK: - .ambiguous (Unconvertible)
+        CelfKey(.bool      , .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.data      , .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.dictionary, .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.double    , .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.int       , .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.string    , .array)     : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.bool      , .dictionary): (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.data      , .dictionary): (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.double    , .dictionary): (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.int       , .dictionary): (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.string    , .dictionary): (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.array     , .double)    : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.data      , .double)    : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.dictionary, .double)    : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.array     , .int)       : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.data      , .int)       : (is: .ambiguous, via: { _ in nil }),
+        CelfKey(.dictionary, .int)       : (is: .ambiguous, via: { _ in nil }),
+    ] }
 }

--- a/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
+++ b/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
@@ -6,70 +6,72 @@ import Foundation
 /// Capable of being encoded as `LeafData`.
 public protocol LeafDataRepresentable {
     /// Converts `self` to `LeafData`, returning `nil` if the conversion is not possible.
-    var leafData: LeafData? { get }
+    var leafData: LeafData { get }
 }
 
 // MARK: Default Conformances
 
 extension String: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .string(self)
-    }
+    public var leafData: LeafData { .string(self) }
 }
 
 extension FixedWidthInteger {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        guard self > Int.min && self < Int.max else {
-            return nil
-        }
-        return .int(Int(self))
+    public var leafData: LeafData {
+        guard let valid = Int(exactly: self) else { return .int(nil) }
+        return .int(Int(valid))
     }
 }
 
-extension Int8: LeafDataRepresentable { }
-extension Int16: LeafDataRepresentable { }
-extension Int32: LeafDataRepresentable { }
-extension Int64: LeafDataRepresentable { }
-extension Int: LeafDataRepresentable { }
-extension UInt8: LeafDataRepresentable { }
-extension UInt16: LeafDataRepresentable { }
-extension UInt32: LeafDataRepresentable { }
-extension UInt64: LeafDataRepresentable { }
-extension UInt: LeafDataRepresentable { }
+extension Int8: LeafDataRepresentable {}
+extension Int16: LeafDataRepresentable {}
+extension Int32: LeafDataRepresentable {}
+extension Int64: LeafDataRepresentable {}
+extension Int: LeafDataRepresentable {}
+extension UInt8: LeafDataRepresentable {}
+extension UInt16: LeafDataRepresentable {}
+extension UInt32: LeafDataRepresentable {}
+extension UInt64: LeafDataRepresentable {}
+extension UInt: LeafDataRepresentable {}
+
+extension BinaryFloatingPoint {
+    public var leafData: LeafData {
+        guard let valid = Double(exactly: self) else { return .double(nil) }
+        return .double(Double(valid))
+    }
+}
+
+extension Float: LeafDataRepresentable {}
+extension Double: LeafDataRepresentable {}
+extension Float80: LeafDataRepresentable {}
 
 extension Bool: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .bool(self)
-    }
-}
-
-extension Double: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .double(self)
-    }
-}
-
-extension Float: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .double(Double(self))
-    }
+    public var leafData: LeafData { .bool(self) }
 }
 
 extension UUID: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .string(description)
-    }
+    public var leafData: LeafData { .string(LeafConfiguration.stringFormatter(description)) }
 }
 
 extension Date: LeafDataRepresentable {
-    /// See `LeafDataRepresentable`
-    public var leafData: LeafData? {
-        return .double(timeIntervalSince1970)
-    }
+    public var leafData: LeafData { .double(timeIntervalSince1970) }
+}
+
+extension Array where Element == LeafData {
+    public var leafData: LeafData { .array(self.map { $0 }) }
+}
+
+extension Dictionary where Key == String, Value == LeafData {
+    public var leafData: LeafData { .dictionary(self.mapValues { $0 }) }
+}
+
+extension Set where Element: LeafDataRepresentable {
+    public var leafData: LeafData { .array(self.map { $0.leafData }) }
+}
+
+extension Array where Element: LeafDataRepresentable {
+    public var leafData: LeafData { .array(self.map { $0.leafData }) }
+}
+
+extension Dictionary where Key == String, Value: LeafDataRepresentable {
+    public var leafData: LeafData { .dictionary(self.mapValues { $0.leafData }) }
 }

--- a/Sources/LeafKit/LeafData/LeafDataStorage.swift
+++ b/Sources/LeafKit/LeafData/LeafDataStorage.swift
@@ -3,46 +3,220 @@
 
 import Foundation
 
-internal enum LeafDataStorage {
-    /// A `Bool`.
-    ///
-    ///     true
-    ///
+internal indirect enum LeafDataStorage: Equatable, CustomStringConvertible {
+    // MARK: - Cases
+    
+    // Static values
     case bool(Bool)
-
-    /// A `String`.
-    ///
-    ///     "hello"
-    ///
     case string(String)
-
-    /// An `Int`.
-    ///
-    ///     42
-    ///
     case int(Int)
-
-    /// A `Double`.
-    ///
-    ///     3.14
-    ///
     case double(Double)
-
-    /// `Data` blob.
-    ///
-    ///     Data([0x72, 0x73])
-    ///
     case data(Data)
-
-    /// A nestable `[String: LeafData]` dictionary.
+    
+    // Collections (potentially holding lazy values)
     case dictionary([String: LeafData])
-
-    /// A nestable `[LeafData]` array.
     case array([LeafData])
 
-    /// A lazily-resolvable `LeafData`.
-    case lazy(() -> (LeafData))
+    // Wrapped `Optional<LeafDataStorage>`
+    case optional(_ wrapped: LeafDataStorage?, _ type: LeafData.NaturalType)
+    
+    // Lazy resolvable function
+    // Must specify return tuple giving (returnType, invariance)
+    case lazy(f: () -> (LeafData),
+              returns: LeafData.NaturalType,
+              invariant: Bool)
+    
+    // MARK: - LeafSymbol Conformance
+    
+    // MARK: Properties
+    internal var resolved: Bool { true }
+    internal var invariant: Bool {
+        switch self {
+            case .lazy(_, _, let invariant): return invariant
+            case .optional(let o, _): return o?.invariant ?? true
+            case .array(let a):
+                let stored = a.map { $0.storage }.filter { $0.isLazy }
+                return stored.allSatisfy { $0.invariant }
+            case .dictionary(let d):
+                let stored = d.values.map { $0.storage }.filter { $0.isLazy }
+                return stored.allSatisfy { $0.invariant }
+            default: return true
+        }
+    }
+    internal var symbols: Set<String> { .init() }
+    internal var isAtomic: Bool { true }
+    internal var isExpression: Bool { false }
+    internal var isAny: Bool { false }
+    internal var isConcrete: Bool { true }
+    /// Note: Will *always* return a value - can be force-unwrapped safely
+    internal var concreteType: LeafData.NaturalType? {
+        switch self {
+            // Concrete Types
+            case .array(_)           : return .array
+            case .bool(_)            : return .bool
+            case .data(_)            : return .data
+            case .dictionary(_)      : return .dictionary
+            case .double(_)          : return .double
+            case .int(_)             : return .int
+            case .string(_)          : return .string
+            // Internal Wrapped Types
+            case .lazy(_, let t, _),
+                 .optional(_, let t) : return t
+        }
+    }
+    
+    // MARK: Functions
+    
+    /// Will resolve anything but variant Lazy data (99% of everything), and unwrap optionals
+    internal func softResolve() -> LeafDataStorage {
+        guard invariant else { return self }
+        switch self {
+            case .lazy(let f, _, _): return f().storage
+            case .optional(let o, _):
+                if let unwrapped = o { return unwrapped }
+                return self
+            case .array(let a):
+                let resolved: [LeafData] = a.map {
+                    LeafData($0.storage.softResolve())
+                }
+                return .array(resolved)
+            case .dictionary(let d):
+                let resolved: [String: LeafData] = d.mapValues {
+                    LeafData($0.storage.softResolve())
+                }
+                return .dictionary(resolved)
+            default: return self
+        }
+    }
 
-    /// Null.
-    case null
+    /// Will resolve anything but variant Lazy data (99% of everything)
+    internal func hardResolve() throws -> LeafData {
+        let resolveStored: LeafDataStorage = self.softResolve()
+        return LeafData(resolveStored)
+    }
+    
+    /// Will serialize anything to a String except Lazy -> Lazy
+    internal func serialize() throws -> String? {
+        let c = LeafConfiguration.self
+        switch self {
+            // Atomic non-containers
+            case .bool(let b)        : return c.boolFormatter(b)
+            case .int(let i)         : return c.intFormatter(i)
+            case .double(let d)      : return c.doubleFormatter(d)
+            case .string(let s)      : return c.stringFormatter(s)
+            // Data
+            case .data(let d)        : return c.dataFormatter(d)
+            // Wrapped
+            case .optional(let o, _) :
+                guard let wrapped = o else { return c.nilFormatter() }
+                return try wrapped.serialize()
+            // Atomic containers
+            case .array(let a)       :
+                let result = try a.map { try $0.storage.serialize() ?? c.nilFormatter() }
+                return c.arrayFormatter(result)
+            case .dictionary(let d)  :
+                let result = try d.mapValues { try $0.storage.serialize() ?? c.nilFormatter()}
+                return c.dictFormatter(result)
+            case .lazy(let f, _, _)  :
+                guard let result = f() as LeafData?,
+                      !result.storage.isLazy else { throw "Lazy can't return Lazy" }
+                return try result.storage.serialize() ?? c.nilFormatter()
+        }
+    }
+    
+    /// Final serialization to a shared buffer
+    internal func serialize(buffer: inout ByteBuffer) throws {
+        let encoding = LeafConfiguration.encoding
+        var data: Data? = nil
+        switch self {
+            case .bool(_),
+                 .int(_),
+                 .double(_),
+                 .string(_),
+                 .lazy(_,_,_),
+                 .optional(_,_),
+                 .array(_),
+                 .dictionary(_) : data = try serialize()!.data(using: encoding)
+            case .data(let d)   : data = d
+        }
+        guard let validData = data else { throw "Serialization Error" }
+        buffer.writeBytes(validData)
+    }
+    
+    // MARK: - Equatable Conformance
+   
+    /// Strict equality comparision, with .nil/.void being equal - will fail on Lazy data that is variant
+    internal static func == (lhs: LeafDataStorage, rhs: LeafDataStorage) -> Bool {
+        // If both sides are optional and nil, equal
+        guard !lhs.isNil || !rhs.isNil else                   { return true  }
+        // Both sides must be non-nil and same concrete type, or unequal
+        guard !lhs.isNil && !rhs.isNil,
+              lhs.concreteType == rhs.concreteType else       { return false }
+        // As long as both are static types, test them
+        if !lhs.isLazy && !rhs.isLazy {
+            switch (lhs, rhs) {
+                // Direct concrete type comparisons
+                case (     .array(let a),      .array(let b)) : return a == b
+                case (.dictionary(let a), .dictionary(let b)) : return a == b
+                case (      .bool(let a),       .bool(let b)) : return a == b
+                case (    .string(let a),     .string(let b)) : return a == b
+                case (       .int(let a),        .int(let b)) : return a == b
+                case (    .double(let a),     .double(let b)) : return a == b
+                case (      .data(let a),       .data(let b)) : return a == b
+                // Both sides are optional, unwrap and compare
+                case (.optional(let l,_), .optional(let r,_)) :
+                        if let l = l, let r = r,
+                                  l == r { return true } else { return false }
+                // ... or unwrap just one side
+                case (.optional(let l,_),                  _) :
+                        if let l = l { return l == rhs } else { return false }
+                case (                 _, .optional(let r,_)) :
+                        if let r = r { return r == lhs } else { return false }
+                default                                       : return false
+            }
+        } else if case .lazy(let lhsF, let lhsR, let lhsI) = lhs,
+                  case .lazy(let rhsF, let rhsR, let rhsI) = rhs {
+            // Only compare lazy equality if invariant to avoid side-effects
+            guard lhsI && rhsI, lhsR == rhsR else             { return false }
+                                                                return lhsF() == rhsF()
+        } else                                                { return false }
+    }
+    
+    // MARK: - CustomStringConvertible
+    var description: String {
+        switch self {
+            case .array(let a)       : return ".array(\(a.count))"
+            case .bool(let b)        : return ".bool(\(b))"
+            case .data(let d)        : return ".data(\(d.count))"
+            case .dictionary(let d)  : return ".dictionary(\(d.count))"
+            case .double(let d)      : return ".double(\(d))"
+            case .int(let i)         : return ".int(\(i))"
+            case .lazy(_, let r, _)  : return ".lazy(() -> .\(r)()?"
+            case .optional(_, let t) : return ".\(t)()?"
+            case .string(let s)      : return ".string(\(s))"
+        }
+    }
+    
+    // MARK: - Other
+    internal var isNil: Bool {
+        switch self {
+            case .optional(let o, _) where o == nil : return true
+            default                                 : return false
+        }
+    }
+    
+    internal var isLazy: Bool {
+        if case .lazy(_,_,_) = self { return true } else { return false }
+    }
+
+    /// Flat mapping behavior - will never re-wrap .optional
+    internal var wrap: LeafDataStorage {
+        if case .optional(_,_) = self { return self }
+        return .optional(self, concreteType!)
+    }
+    
+    internal var unwrap: LeafDataStorage? {
+        guard case .optional(let optional, _) = self else { return self }
+        return optional
+    }
 }

--- a/Sources/LeafKit/LeafParser/LeafParser.swift
+++ b/Sources/LeafKit/LeafParser/LeafParser.swift
@@ -300,8 +300,8 @@ internal struct LeafParser {
                     switch params[0] {
                         case .parameter(let p):
                             switch p {
-                                case .variable(name: let n):
-                                    return .variable(.init(path: n))
+                                case .variable(_):
+                                    return .expression([params[0]])
                                 case .constant(let c):
                                     var buffer = ByteBufferAllocator().buffer(capacity: 0)
                                     buffer.writeString(c.description)

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -1,34 +1,4 @@
 // MARK: Subject to change prior to 1.0.0 release
-// MARK: -
-
-/// General configuration of Leaf
-/// - Sets the default View directory where templates will be looked for
-/// - Guards setting the global tagIndicator (default `#`).
-public struct LeafConfiguration {
-    public var rootDirectory: String
-    
-    /// Initialize Leaf with the default tagIndicator `#`
-    /// - Parameter rootDirectory: Default directory where templates will be found
-    public init(rootDirectory: String) {
-        self.init(rootDirectory: rootDirectory, tagIndicator: .octothorpe)
-    }
-    
-    /// Initialize Leaf
-    /// - Parameter rootDirectory: Default directory where templates will be found
-    /// - Parameter tagIndicator: Unique tagIndicator
-    public init(rootDirectory: String, tagIndicator: Character) {
-        if !LeafConfiguration.tagIndicatorIsSet {
-            Character.tagIndicator = tagIndicator
-            LeafConfiguration.tagIndicatorIsSet = true
-        }
-        self.rootDirectory = rootDirectory
-    }
-    
-    // MARK: - Internal/Private Only
-    
-    /// Convenience flag for write-once
-    fileprivate static var tagIndicatorIsSet = false
-}
 
 // MARK: - `LeafRenderer` Summary
 

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -1,19 +1,21 @@
-// MARK: Subject to change prior to 1.0.0 release
-// MARK: -
-
-// FIXME: - `Syntax` is overly monolithic and should *not* be public
-///
-
 public indirect enum Syntax {
+    // MARK: .raw - Makeable, Entirely Readable
     case raw(ByteBuffer)
-    case variable(Variable)
+    // MARK: `case variable(Variable)` removed
+    // MARK: .expression - Makeable, Entirely Readable
     case expression([ParameterDeclaration])
+    // MARK: .custom - Unmakeable, Semi-Readable
     case custom(CustomTagDeclaration)
 
+    // MARK: .conditional - Makeable, Entirely Readable
     case conditional(Conditional)
+    // MARK: .loop - Makeable, Semi-Readable
     case loop(Loop)
+    // MARK: .`import` - Makeable, Readable (Pointlessly)
     case `import`(Import)
+    // MARK: .extend - Makeable, Semi-Readable
     case extend(Extend)
+    // MARK: .export - Makeable, Semi-Readable
     case export(Export)
 }
 
@@ -269,7 +271,7 @@ extension Syntax {
                             results.removeLast()
                             results.append(raw)
                         }
-                    }                    
+                    }
                 }
             }
             
@@ -511,28 +513,6 @@ extension Syntax {
         }
     }
 
-    public struct Variable {
-        public let path: [String]
-
-        public init(path: String) {
-            self.path = path.split(separator: ".").map(String.init)
-        }
-
-        public init(_ params: [ParameterDeclaration]) throws {
-            guard params.count == 1 else { throw "only single parameter variable supported currently" }
-            guard case .parameter(let p) = params[0] else { throw "expected single parameter, got: \(params)" }
-            switch p {
-                case .variable(let n):
-                    self.init(path: n)
-                default: throw "todo: implement constant and literal? maybe process earlier as not variable, but raw.. \(p)"
-            }
-        }
-
-        func print(depth: Int) -> String {
-            return indent(depth) + "variable(" + path.joined(separator: ".") + ")"
-        }
-    }
-
     public struct CustomTagDeclaration: BodiedSyntax {
         public let name: String
         public let params: [ParameterDeclaration]
@@ -586,7 +566,7 @@ extension Syntax: CustomStringConvertible {
     func print(depth: Int) -> String {
         switch self {
             case .expression(let exp): return indent(depth) + "expression\(exp.description)"
-            case .variable(let v):     return v.print(depth: depth)
+ //           case .variable(let v):     return v.print(depth: depth)
             case .custom(let custom):  return custom.print(depth: depth)
             case .conditional(let c):  return c.print(depth: depth)
             case .loop(let loop):      return loop.print(depth: depth)

--- a/Tests/LeafKitTests/LeafKitTests.swift
+++ b/Tests/LeafKitTests/LeafKitTests.swift
@@ -60,7 +60,7 @@ final class ParserTests: XCTestCase {
             raw("\\n    abc\\n    ")
             for(name in names):
               raw("\\n        hi, ")
-              variable(name)
+              expression[variable(name)]
               raw("\\n    ")
             raw("\\n    def\\n")
           else:
@@ -140,7 +140,7 @@ final class ParserTests: XCTestCase {
         raw("<h1>")
         import("header")
         raw("</h1>\\n<title>Welcome</title>\\n\\n        Hello, ")
-        variable(name)
+        expression[variable(name)]
         raw("!\\n    ")
         """
         XCTAssertEqual(output, expectation)
@@ -160,7 +160,7 @@ final class ParserTests: XCTestCase {
         extend("base"):
           export("body"):
             raw("\\n        Hello, ")
-            variable(name)
+            expression[variable(name)]
             raw("!\\n    ")
           export("title"):
             expression[stringLiteral("Welcome")]

--- a/Tests/LeafKitTests/TestHelpers.swift
+++ b/Tests/LeafKitTests/TestHelpers.swift
@@ -170,8 +170,9 @@ final class PrintTests: XCTestCase {
         let expectation = "variable(foo)"
         
         let v = try parse(template).first!
-        guard case .variable(let test) = v else { throw "nope" }
-        let output = test.print(depth: 0)
+        guard case .expression(let e) = v,
+              let test = e.first else { throw "nope" }
+        let output = test.description
         XCTAssertEqual(output, expectation)
     }
 
@@ -184,7 +185,7 @@ final class PrintTests: XCTestCase {
         let expectation = """
         for(name in names):
           raw("\\n    hello, ")
-          variable(name)
+          expression[variable(name)]
           raw(".\\n")
         """
         


### PR DESCRIPTION
This release adds configuration methods for setting the default presentation output of data in rendered Leaf templates.

These options are all settable before LeafKit starts running.

### Property Options

Stored property options in a `LeafConfiguration` may be used in various ways by a `LeafRenderer` which the configuration object was for, and changes to them after the object was provided to a specific `LeafRenderer` will have no affect.

```swift
.rootDirectory: String   // The default file directory used for file-system based `LeafSource`s                  
```

### Static Options

Static options on `LeafConfiguration` are effectively constant once any `LeafRenderer` has been instantiated and attempts to change them will assert in `Debug` and silently fail in `Release` to prevent inconsistent behavior.

```swift
 // The global tag indicator for LeafKit
.tagIndicator: Character == "#"
 // Encoding used when a template is serialized
.encoding: String.Encoding == .utf8

// Formatters for converting the base internal data types to Strings for serialization
.boolFormatter: (Bool) -> String = { $0.description }     // Bool.description
.intFormatter: (Int) -> String = { $0.description }       // Int.description
.doubleFormatter: (Double) -> String = { $0.description } // Double.description
.nilFormatter: () -> String = { "" }                      // Empty string (Optional containing .none)
.voidFormatter: () -> String = { "" }                     // Empty string (Tag with no return value)
.stringFormatter: (String) -> String = { $0 }             // Identity return
.dataFormatter: (Data) -> String? =
        { String(data: $0, encoding: Self._encoding) }    // Data using .encoding

// Note: Array & Dictionaries elements will already have been converted to Strings

.arrayFormatter: ([String]) -> String =                   // Array: [element, ..., element]
        { "[\($0.map {"\"\($0)\""}.joined(separator: ", "))]" }
.dictFormatter: ([String: String]) -> String =            // Dictionary: [key: value, ..., key: value]
        { "[\($0.map { "\($0): \"\($1)\"" }.joined(separator: ", "))]" }

```

### API Changes

* `Character.tagIndicator` can no longer be directly set - it must be configured through `LeafConfiguration`

* `LeafData.NaturalType` represents eight concrete Swift data types Leaf handles:
  - Instantiable data types: [Bool, Int, Double, String, Array, Dictionary, Data]
  - Non-instantiable: [Void]

* `LeafData` static initializers from Swift data types now take Optional values:
  - If input is `.none`, the returned `LeafData` represents a `Optional.none` state of the specific type
  - `.nil` static initializer now requires a concrete type from `LeafData.NaturalType` be specified

* `LeafData` objects present the following informational states:
  * `celf` : NaturalType of the object
  * `isNil`: whether the object contains `.none`
  * `isCollection`:  if the object's type is `array` or `dictionary`.
  * `isCastable(to type: NaturalType)`: whether the type is implicitly castable to a second type
  * `isCoercible(to type: NaturalType)`: whether the type has an implicit one-way conersion path to the second type
  * **NOTE** both above methods are inherently true when the two types are the same type, or castable when asking if coercible.
  * `hasUniformType`: whether the object consists of one concrete type (true for all non-containers), false if it can be determined that it does not, and nil in unusual cases where an object is storing an internal dynamic data generator that returns a container itself.
  * `uniformType`: If the object can be determined to have a `uniformType`, returns that type or nil if not determinable.

* **`LeafDataRepresentable` adherence now requires `.leafData` return `LeafData` rather than `LeafData?`**
  * Updated static initalizers mentioned above will automatically handle creating `LeafData` holding `.none` where otherwise a nil return would occur
  * Generic conformances for various Swift base types are updated to reflect this:
    * ```swift
      let invalidValue: Float80 = Float80.max
      let leafData = invalidValue.leafData
      // leafData now represents the equivalent of Double? containing nil
      ```
    * Default implementations for protocols `FixedWidthInteger` and `BinaryFloatingPoint`
    * Adherance via above for `Bool`, `String`, `Int/Int8/Int32/Int64/UInt/UInt8/UInt16/UInt32/UInt64`, `Float/Double/Float80`, `Data`, `UUID` (via String), `Date` (via Double), `Array<LeafDataRepresentable>`, `Dictionary<String, LeafDataRepresentable>`, `Set<LeafDataRepresentable>` via Array

### Internal Only

Substantial internal changes to `LeafData`, `LeafDataRepresentable` Protocol, `LeafDataStorage` :

* `LeafData` conversion between types is now explicitly handled by `castable` and `coercible` rules where underlying types are different. The default behaviors allow only implicit conversion via `castable` rules where a clearly established bi-directional rule exists between the two types.
* `LeafDataStorage` signifcantly modified to allow above behaviors
  * Internal `Lazy` resolvable data generators must now state their concrete return type and whether they have variant return behavior; such generators will never be tested in any kind of comparison states to prevent side-effects - they will only be called when a template serializes.
  * Various state evaluation, data conversion, and related behaviors are moved internally to the enum definition to prevent confusing situations
* Various internal changes reflecting the above modifications


### Fixes
* Throws an error if overflowing add/subtract on integer values