### PR TITLE
Fix compiler error on non-x86 architecture builds

### DIFF
--- a/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
+++ b/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
@@ -42,7 +42,9 @@ extension BinaryFloatingPoint {
 
 extension Float: LeafDataRepresentable {}
 extension Double: LeafDataRepresentable {}
+#if arch(i386) || arch(x86_64)
 extension Float80: LeafDataRepresentable {}
+#endif
 
 extension Bool: LeafDataRepresentable {
     public var leafData: LeafData { .bool(self) }


### PR DESCRIPTION
To fix compiler error on non-X86 architectures. Issue https://github.com/vapor/leaf-kit/issues/69 refers.

Adds compiler directive in LeafDataRepresentative.swift to remove redundant extension to Float80.