### PR TITLE
Invariant Entities

### DIFF
--- a/Sources/LeafKit/LeafEntities/LeafCallParameter.swift
+++ b/Sources/LeafKit/LeafEntities/LeafCallParameter.swift
@@ -124,7 +124,7 @@ internal extension LeafCallParameter {
         /// If only one type, return coerced value as long as it doesn't coerce to .trueNil (and for .bool always true)
         if types.count == 1 {
             let coerced = value.coerce(to: types.first!)
-            return coerced != .trueNil ? coerced : types.first! == .bool ? .bool(true) : .none
+            return !coerced.isTrueNil ? coerced : types.first! == .bool ? .bool(true) : .none
         }
         /// Otherwise assume function will handle coercion itself as long as one potential match exists
         return types.first(where: {value.isCoercible(to: $0)}) != nil ? value : .none

--- a/Sources/LeafKit/LeafParser/LKParser.swift
+++ b/Sources/LeafKit/LeafParser/LKParser.swift
@@ -597,6 +597,7 @@ internal struct LKParser {
             var a = a
             /// If an invariant function with all literal params, and not a mutating or unsafe object, evaluate immediately
             if case .function(_, .some(let f), let t, _, _) = a.container,
+               f.invariant,
                f as? LKMetaBlock == nil,
                f as? LeafMutatingMethod == nil,
                f as? LeafUnsafeEntity == nil,

--- a/Tests/LeafKitTests/LeafParserTests.swift
+++ b/Tests/LeafKitTests/LeafParserTests.swift
@@ -680,5 +680,10 @@ final class LeafParserTests: MemoryRendererTestCase {
         
         try LKXCAssertErrors(render("template"), contains: "Assignment via subscripted access not yet supported")
     }
+    
+    func testInvariantFunc() throws {
+        try XCTAssertEqual(parse(raw: "#(Timestamp())").terse,
+                           "0: Timestamp(string(now), string(referenceDate))")
+    }
 }
 


### PR DESCRIPTION
Fix bug where LKParser failed to honor `invariant` flag on entities in parameter tuple parsing and evaluated immediately when parameters are all literal