### PR TITLE
Correctly parsing non Leaf `#` tag.

### DIFF
--- a/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
@@ -76,7 +76,7 @@ internal struct LeafSerializer {
             body: tag.body,
             userInfo: self.userInfo
         )
-        let leafData = try self.tags[tag.name]?.render(sub) ?? LeafData.trueNil
+        let leafData = try self.tags[tag.name]?.render(sub) ?? LeafData("#\(tag.name)")
         try? leafData.serialize(buffer: &self.buffer)
     }
 

--- a/Sources/LeafKit/LeafSyntax/LeafTag.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafTag.swift
@@ -10,7 +10,8 @@ public var defaultTags: [String: LeafTag] = [
     "capitalized": Capitalized(),
     "contains": Contains(),
     "date": DateTag(),
-    "count": Count()
+    "count": Count(),
+    "comment": Comment()
 ]
 
 struct Lowercased: LeafTag {
@@ -85,5 +86,11 @@ struct Count: LeafTag {
         } else {
             throw "Unable to convert count parameter to LeafData collection"
         }
+    }
+}
+
+struct Comment: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        LeafData.trueNil
     }
 }

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -15,8 +15,7 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template), "foo\n\nbar")
     }
 
-    // TODO - add in future release
-    func _testHashtag() throws {
+    func testHashtag() throws {
         let template = """
         #("hi") #thisIsNotATag...
         """


### PR DESCRIPTION
It includes the following changes:

* Literally output the non Leaf `#` tags.
* Add the explicit support for `#comment` tag.
* Enable the corresponding unit test.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
