### PR TITLE
WIP: Added async signature to LeafRenderer

### DIFF
--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -80,6 +80,10 @@ public final class LeafRenderer {
         }
     }
     
+    public func render(path: String, context: [String: LeafData]) async throws -> ByteBuffer {
+        try await render(path: path, context: context).get()
+    }
+    
     
     // MARK: - Internal Only
     /// Temporary testing interface


### PR DESCRIPTION
I'm wondering if it would be beneficial to add an `async` overload to the `render(path:context:)` method. I'm opening this PR with an example of what I'm referring to, and if it seems useful, I am happy to clean it up with documentation and any other changes requested.

I've done the same thing in my [PlotVapor](https://github.com/bdrelling/PlotVapor/blob/main/Source/PlotRenderer.swift#L33-L35) package, and the ability to simply change the closure signature without having to append `.get()` to every `render` call is very nice.

If this is seen as a negative addition to the SDK, I would love to understand why as well so I can make the same consideration in my related package. 

Thank you!