### PR TITLE
Add #dumpContext tag

### DIFF
--- a/Sources/LeafKit/LeafSyntax/LeafTag.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafTag.swift
@@ -16,7 +16,8 @@ public var defaultTags: [String: LeafTag] = [
     "contains": Contains(),
     "date": DateTag(),
     "count": Count(),
-    "comment": Comment()
+    "comment": Comment(),
+    "dumpContext": DumpContext()
 ]
 
 struct UnsafeHTML: UnsafeUnescapedLeafTag {
@@ -106,5 +107,12 @@ struct Count: LeafTag {
 struct Comment: LeafTag {
     func render(_ ctx: LeafContext) throws -> LeafData {
         LeafData.trueNil
+    }
+}
+
+struct DumpContext: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        try ctx.requireParameterCount(0)
+        return LeafData(.dictionary(ctx.data))
     }
 }

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -176,6 +176,18 @@ class TagTests: XCTestCase {
         try XCTAssertEqual(render(template, ["now": .int(now)]), expected)
     }
 
+    func testDumpContext() throws {
+        let data: [String: LeafData] = ["value": 12345, "nested": ["message": "foo"]]
+        let template = """
+        dumpContext should output debug description #dumpContext()
+        """
+
+        let expected = """
+        dumpContext should output debug description [value: "12345", nested: "[message: "foo"]"]
+        """
+
+        try XCTAssertEqual(render(template, data), expected)
+    }
 
     func testPerformance() throws {
         let template = """

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -177,13 +177,13 @@ class TagTests: XCTestCase {
     }
 
     func testDumpContext() throws {
-        let data: [String: LeafData] = ["value": 12345, "nested": ["message": "foo"]]
+        let data: [String: LeafData] = ["value": 12345]
         let template = """
-        dumpContext should output debug description #dumpContext()
+        dumpContext should output debug description #dumpContext
         """
 
         let expected = """
-        dumpContext should output debug description [value: "12345", nested: "[message: "foo"]"]
+        dumpContext should output debug description [value: "12345"]
         """
 
         try XCTAssertEqual(render(template, data), expected)


### PR DESCRIPTION
Adds a new tag, `#dumpContext()` that renders the whole context for easy debugging