### PR TITLE
add isEmpty tag

### DIFF
--- a/Sources/LeafKit/LeafSyntax/LeafTag.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafTag.swift
@@ -14,6 +14,7 @@ public var defaultTags: [String: LeafTag] = [
     "uppercased": Uppercased(),
     "capitalized": Capitalized(),
     "contains": Contains(),
+    "isEmpty": IsEmpty(),
     "date": DateTag(),
     "count": Count(),
     "comment": Comment(),
@@ -64,6 +65,15 @@ struct Contains: LeafTag {
         }
         let result = collection.contains(ctx.parameters[1])
         return .init(.bool(result))
+    }
+}
+
+struct IsEmpty: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        guard let str = ctx.parameters.first?.string else {
+            throw "unable to check for empty value unexpected data"
+        }
+        return .init(.bool(str.isEmpty))
     }
 }
 

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -117,6 +117,21 @@ class TagTests: XCTestCase {
         """
         try XCTAssertEqual(render(template, ["core": ["Tanner", "Logan", "Gwynne", "Siemen", "Tim"]]), expected)
     }
+    
+    func testIsEmpty() throws {
+        let template = """
+        #if(isEmpty(emptyString)):
+            This is an empty string.
+        #endif
+        """
+
+        let expected = """
+
+            This is an empty string.
+
+        """
+        try XCTAssertEqual(render(template, ["emptyString": ""]), expected)
+    }
 
     func testContainsTagWithHTML() throws {
         let template = """

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -132,6 +132,23 @@ class TagTests: XCTestCase {
         """
         try XCTAssertEqual(render(template, ["emptyString": ""]), expected)
     }
+    
+    func testIsEmptyFalseCase() throws {
+        let template = """
+        #if(isEmpty(nonEmptyString)):
+            This is an empty string.
+        #else:
+            This is not an empty string.
+        #endif
+        """
+
+        let expected = """
+
+            This is not an empty string.
+
+        """
+        try XCTAssertEqual(render(template, ["nonEmptyString": "I'm not empty."]), expected)
+    }
 
     func testContainsTagWithHTML() throws {
         let template = """


### PR DESCRIPTION
Adds a new `isEmpty` tag for checking empty Strings. Equivalent of Swift's `isEmpty`

Example:
```leaf
#if(isEmpty(emptyString)):
    This is an empty string.
#endif
```