### PR TITLE
Extend for loops with custom index support

### DIFF
--- a/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
@@ -141,7 +141,7 @@ internal struct LeafSerializer {
 
             innerContext["isFirst"] = .bool(idx == array.startIndex)
             innerContext["isLast"] = .bool(idx == array.index(before: array.endIndex))
-            innerContext["index"] = .int(idx)
+            innerContext[loop.index] = .int(idx)
             innerContext[loop.item] = item
 
             var serializer = LeafSerializer(

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -562,11 +562,11 @@ extension Syntax {
             } else {
                 guard
                     params.count == 2,
-                    case .parameter(.variable(let item)) = params[0],
+                    case .parameter(.variable(let index)) = params[0],
                     case .expression(let list) = params[1],
                     list.count == 3,
                     case .parameter(let left) = list[0],
-                    case .variable(let index) = left,
+                    case .variable(let item) = left,
                     case .parameter(let `in`) = list[1],
                     case .keyword(let k) = `in`,
                     k == .in,
@@ -608,7 +608,7 @@ extension Syntax {
         
         func print(depth: Int) -> String {
             var print = indent(depth)
-            print += "for(" + item + (index == "index" ? "" : ", \(index)") + " in " + array + "):\n"
+            print += "for(" + (index == "index" ? "" : "\(index), ") + item + " in " + array + "):\n"
             print += body.map { $0.print(depth: depth + 1) } .joined(separator: "\n")
             return print
         }

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -328,6 +328,34 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template, ["arrays": data]), expected)
     }
 
+    func testNestedLoopCustomIndices() throws {
+        let template = """
+        #for(array, aIndex in arrays):#for(element, eIndex in array):
+        (#(aIndex), #(eIndex)): #(element)#endfor#endfor
+        """
+
+        let expected = """
+
+        (0, 0): zero
+        (0, 1): one
+        (0, 2): two
+        (1, 0): a
+        (1, 1): b
+        (1, 2): c
+        (2, 0): red fish
+        (2, 1): blue fish
+        (2, 2): green fish
+        """
+
+        let data = LeafData.array([
+            LeafData.array(["zero", "one", "two"]),
+            LeafData.array(["a", "b", "c"]),
+            LeafData.array(["red fish", "blue fish", "green fish"])
+        ])
+
+        try XCTAssertEqual(render(template, ["arrays": data]), expected)
+    }
+
     // It would be nice if a pre-render phase could catch things like calling
     // tags that would normally ALWAYS throw in serializing (eg, calling index
     // when not in a loop) so that warnings can be provided and AST can be minimized.

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -330,8 +330,8 @@ final class LeafTests: XCTestCase {
 
     func testNestedLoopCustomIndices() throws {
         let template = """
-        #for(array, aIndex in arrays):#for(element, eIndex in array):
-        (#(aIndex), #(eIndex)): #(element)#endfor#endfor
+        #for(i, array in arrays):#for(j, element in array):
+        (#(i), #(j)): #(element)#endfor#endfor
         """
 
         let expected = """

--- a/Tests/LeafKitTests/TestHelpers.swift
+++ b/Tests/LeafKitTests/TestHelpers.swift
@@ -196,6 +196,27 @@ final class PrintTests: XCTestCase {
         XCTAssertEqual(output, expectation)
     }
 
+    func testLoopCustomIndex() throws {
+        let template = """
+        #for(name, nin in names):
+            #(nin): hello, #(name).
+        #endfor
+        """
+        let expectation = """
+        for(name, nin in names):
+          raw("\\n    ")
+          expression[variable(nin)]
+          raw(": hello, ")
+          expression[variable(name)]
+          raw(".\\n")
+        """
+
+        let v = try parse(template).first!
+        guard case .loop(let test) = v else { throw "nope" }
+        let output = test.print(depth: 0)
+        XCTAssertEqual(output, expectation)
+    }
+
     func testConditional() throws {
         let template = """
         #if(foo):

--- a/Tests/LeafKitTests/TestHelpers.swift
+++ b/Tests/LeafKitTests/TestHelpers.swift
@@ -198,14 +198,14 @@ final class PrintTests: XCTestCase {
 
     func testLoopCustomIndex() throws {
         let template = """
-        #for(name, nin in names):
-            #(nin): hello, #(name).
+        #for(i, name in names):
+            #(i): hello, #(name).
         #endfor
         """
         let expectation = """
-        for(name, nin in names):
+        for(i, name in names):
           raw("\\n    ")
-          expression[variable(nin)]
+          expression[variable(i)]
           raw(": hello, ")
           expression[variable(name)]
           raw(".\\n")


### PR DESCRIPTION
Traditionally, the `for` loops in Leaf declare three variables in the loop's local context: `isFirst`, `isLast` and `index`. The first two aren't particularly interesting, but being able to access all indices in a *nested* for loop situation is sometimes useful when working with two dimensions at once. Not to mention it just popped up on Discord earlier today.

This PR extends Loop with the option of renaming `index`.

Example syntax:

```leaf
#for(i, array in arrays):
  #for(j, element in array):
    (#(i), #(j)): #(element)
  #endfor
#endfor
```

---

Should be semver-minor.