### PR TITLE
Fix error message in loop syntax

### DIFF
--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -555,7 +555,7 @@ extension Syntax {
                     k == .in,
                     case .parameter(let right) = list[2],
                     case .variable(let array) = right
-                    else { throw "for loops expect one of the following expressions: 'name in names' or 'name, nameIndex in names'" }
+                    else { throw "for loops expect one of the following expressions: 'name in names' or 'nameIndex, name in names'" }
                 self.item = item
                 self.array = array
                 self.index = "index"

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -572,7 +572,7 @@ extension Syntax {
                     k == .in,
                     case .parameter(let right) = list[2],
                     case .variable(let array) = right
-                else { throw "for loops expect one of the following expressions: 'name in names' or 'name, nameIndex in names'" }
+                else { throw "for loops expect one of the following expressions: 'name in names' or 'nameIndex, name in names'" }
                 self.item = item
                 self.array = array
                 self.index = index


### PR DESCRIPTION
Syntax errors thrown from loops now show the correct error message!
