### PR TITLE
Fix nested extend with sugar

### DIFF
--- a/Sources/LeafKit/LeafAST.swift
+++ b/Sources/LeafKit/LeafAST.swift
@@ -62,13 +62,7 @@ public struct LeafAST: Hashable {
             }
             
             // replace the original Syntax with the results of inlining, potentially 1...n
-            let replacementSyntax: [Syntax]
-            if case .extend(let extend) = ast[pos], let context = extend.context {
-                let inner = ast[pos].inlineRefs(providedExts, [:])
-                replacementSyntax = [.with(.init(context: context, body: inner))]
-            } else {
-                replacementSyntax = ast[pos].inlineRefs(providedExts, [:])
-            }
+            let replacementSyntax = ast[pos].inlineRefs(providedExts, [:])
             ast.replaceSubrange(pos...pos, with: replacementSyntax)
             // any returned new inlined syntaxes can't be further resolved at this point
             // but we need to add their unresolvable references to the global set

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -105,6 +105,10 @@ extension Syntax: BodiedSyntax  {
     }
     
     internal func inlineRefs(_ externals: [String: LeafAST], _ imports: [String: Export]) -> [Syntax] {
+        if case .extend(let extend) = self, let context = extend.context {
+            let inner = extend.inlineRefs(externals, imports)
+            return [.with(.init(context: context, body: inner))]
+        }
         var result = [Syntax]()
         switch self {
             case .import(let im):

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -252,6 +252,39 @@ final class LeafTests: XCTestCase {
         XCTAssertEqual(str, expected)
     }
 
+    func testNestedExtendWithSugar() throws {
+        let layout = """
+        <body>#import("content")</body>
+        """
+
+        let header = """
+        <h1>#(child)</h1>
+        """
+
+        let base = """
+        #extend("layout"):#export("content"):<main>#extend("header", parent)</main>#endexport#endextend
+        """
+
+        let expected = """
+        <body><main><h1>Elizabeth</h1></main></body>
+        """
+
+        let layoutAST = try LeafAST(name: "layout", ast: parse(layout))
+        let headerAST = try LeafAST(name: "header", ast: parse(header))
+        let baseAST = try LeafAST(name: "base", ast: parse(base))
+
+        let baseResolved = LeafAST(from: baseAST, referencing: ["layout": layoutAST, "header": headerAST])
+
+        var serializer = LeafSerializer(
+            ast: baseResolved.ast,
+            ignoreUnfoundImports: false
+        )
+        let view = try serializer.serialize(context: ["parent": ["child": "Elizabeth"]])
+        let str = view.getString(at: view.readerIndex, length: view.readableBytes) ?? ""
+
+        XCTAssertEqual(str, expected)
+    }
+
     func testEmptyForLoop() throws {
         let template = """
         #for(category in categories):


### PR DESCRIPTION
When nesting an `#extend` with two parameters, the second parameter was ignored instead of being used as context.

Fixes vapor/leaf-kit#126