### PR TITLE
Fix extend not rendered when wrapped by with

### DIFF
--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -85,6 +85,7 @@ extension Syntax: BodiedSyntax  {
                  .custom(let bS as BodiedSyntax),
                  .export(let bS as BodiedSyntax),
                  .extend(let bS as BodiedSyntax),
+                 .with(let bS as BodiedSyntax),
                  .loop(let bS as BodiedSyntax): return bS.externals()
             default: return .init()
         }
@@ -125,6 +126,7 @@ extension Syntax: BodiedSyntax  {
                  .custom(let bS as BodiedSyntax),
                  .export(let bS as BodiedSyntax),
                  .extend(let bS as BodiedSyntax),
+                 .with(let bS as BodiedSyntax),
                  .loop(let bS as BodiedSyntax): result += bS.inlineRefs(externals, imports)
             case .expression(let pDA): result.append(.expression(pDA.inlineImports(imports)))
             // .variable, .raw

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -224,6 +224,34 @@ final class LeafTests: XCTestCase {
         try XCTAssertEqual(render(template, ["parent": ["child": "Elizabeth"]]), expected)
     }
 
+    func testWithWrappingExtend() throws {
+        let header = """
+        <h1>#(child)</h1>
+        """
+
+        let base = """
+        <body>#with(parent):<main>#extend("header")</main>#endwith</body>
+        """
+
+        let expected = """
+        <body><main><h1>Elizabeth</h1></main></body>
+        """
+
+        let headerAST = try LeafAST(name: "header", ast: parse(header))
+        let baseAST = try LeafAST(name: "base", ast: parse(base))
+
+        let baseResolved = LeafAST(from: baseAST, referencing: ["header": headerAST])
+
+        var serializer = LeafSerializer(
+            ast: baseResolved.ast,
+            ignoreUnfoundImports: false
+        )
+        let view = try serializer.serialize(context: ["parent": ["child": "Elizabeth"]])
+        let str = view.getString(at: view.readerIndex, length: view.readableBytes) ?? ""
+
+        XCTAssertEqual(str, expected)
+    }
+
     func testExtendWithSugar() throws {
         let header = """
         <h1>#(child)</h1>


### PR DESCRIPTION
When an `#extend` was wrapped by a `#with`, the `#extend` wasn't rendered.

Fixes vapor/leaf-kit#128