### PR TITLE
Fix crash with missing parameter

### DIFF
--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -32,7 +32,7 @@ public struct LeafError: Error {
         /// - Provide template name & ordered array of template names that causes the cycle path
         case cyclicalReference(String, [String])
         /// Parameter missing
-        case missingParameter(String)
+        case missingParameter
 
         // MARK: Wrapped Errors related to Lexing or Parsing
         /// Errors due to malformed template syntax or grammar
@@ -86,8 +86,8 @@ public struct LeafError: Error {
                 return "\(src) - \(key) cyclically referenced in [\(chain.joined(separator: " -> "))]"
             case .lexerError(let e):
                 return "Lexing error - \(e.localizedDescription)"
-            case .missingParameter(let message):
-                return message
+            case .missingParameter:
+                return "Expected a parameter but found none"
         }
     }
     

--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -31,6 +31,8 @@ public struct LeafError: Error {
         /// Attempt to render an AST with cyclical external references
         /// - Provide template name & ordered array of template names that causes the cycle path
         case cyclicalReference(String, [String])
+        /// Parameter missing
+        case missingParameter(String)
 
         // MARK: Wrapped Errors related to Lexing or Parsing
         /// Errors due to malformed template syntax or grammar
@@ -84,6 +86,8 @@ public struct LeafError: Error {
                 return "\(src) - \(key) cyclically referenced in [\(chain.joined(separator: " -> "))]"
             case .lexerError(let e):
                 return "Lexing error - \(e.localizedDescription)"
+            case .missingParameter(let message):
+                return message
         }
     }
     

--- a/Sources/LeafKit/LeafError.swift
+++ b/Sources/LeafKit/LeafError.swift
@@ -31,8 +31,6 @@ public struct LeafError: Error {
         /// Attempt to render an AST with cyclical external references
         /// - Provide template name & ordered array of template names that causes the cycle path
         case cyclicalReference(String, [String])
-        /// Parameter missing
-        case missingParameter
 
         // MARK: Wrapped Errors related to Lexing or Parsing
         /// Errors due to malformed template syntax or grammar
@@ -86,8 +84,6 @@ public struct LeafError: Error {
                 return "\(src) - \(key) cyclically referenced in [\(chain.joined(separator: " -> "))]"
             case .lexerError(let e):
                 return "Lexing error - \(e.localizedDescription)"
-            case .missingParameter:
-                return "Expected a parameter but found none"
         }
     }
     

--- a/Sources/LeafKit/LeafParser/LeafParser.swift
+++ b/Sources/LeafKit/LeafParser/LeafParser.swift
@@ -200,7 +200,13 @@ internal struct LeafParser {
                     let params = try readParameters()
                     // parameter tags not permitted to have bodies
                     if params.count > 1  { group.append(.expression(params)) }
-                    else { group.append(params.first!) }
+                    ///// else { group.append(params.first!) }
+                    else {
+                      guard let firstParam = params.first else {
+                        throw LeafError(.missingParameter("Expected a parameter but found none"))
+                      }
+                      group.append(firstParam)
+                    }
                 case .parameter(let p):
                     pop()
                     switch p {

--- a/Sources/LeafKit/LeafParser/LeafParser.swift
+++ b/Sources/LeafKit/LeafParser/LeafParser.swift
@@ -193,7 +193,7 @@ internal struct LeafParser {
             guard let first = group.first else {
               // It's better to handle this case as well, even though logically it might never happen
               // since you're checking if group.isEmpty before.
-              throw LeafError(.missingParameter, file: #file, function: #function, line: #line, column: #column)
+              throw LeafError(.unknownError("Found nil while iterating through params"), file: #file, function: #function, line: #line, column: #column)
             }
             paramsList.append(first)
           }
@@ -209,7 +209,7 @@ internal struct LeafParser {
                     if params.count > 1  { group.append(.expression(params)) }
                     else {
                       guard let firstParam = params.first else {
-                        throw LeafError(.missingParameter)
+                        throw LeafError(.unknownError("Found nil while iterating through params"))
                       }
                       group.append(firstParam)
                     }

--- a/Tests/LeafKitTests/LeafErrorTests.swift
+++ b/Tests/LeafKitTests/LeafErrorTests.swift
@@ -53,18 +53,12 @@ final class LeafErrorTests: XCTestCase {
       test.files["/missingParam.leaf"] = """
           #(foo.bar.trim())
           """
-      do {
-        _ = try TestRenderer(sources: .singleSource(test)).render(path: "missingParam", context: [:]).wait()
-        XCTFail("Should have thrown LeafError.missingParameter")
-      } catch let error as LeafError {
-        switch error.reason {
-        case .missingParameter:
-          return
-        default:
-          XCTFail("Wrong error: \(error.localizedDescription)")
+        XCTAssertThrowsError(try TestRenderer(sources: .singleSource(test))
+            .render(path: "missingParam", context: [:])
+            .wait()
+        ) {
+            guard case .missingParameter = ($0 as? LeafError)?.reason else {
+                return XCTFail("Expected LeafError.missingParameter, got \(String(reflecting: $0))")
+            }
         }
-      } catch {
-        XCTFail("Wrong error: \(error.localizedDescription)")
-      }
-    }
 }

--- a/Tests/LeafKitTests/LeafErrorTests.swift
+++ b/Tests/LeafKitTests/LeafErrorTests.swift
@@ -45,4 +45,26 @@ final class LeafErrorTests: XCTestCase {
             XCTFail("Wrong error: \(error.localizedDescription)")
         }
     }
+    
+    /// Verify that rendering a template with a missing required parameter will throw `LeafError.missingParameter`
+    func testMissingParameterError() {
+      var test = TestFiles()
+      // Assuming "/missingParam.leaf" is a template that requires a parameter we intentionally don't provide
+      test.files["/missingParam.leaf"] = """
+          #(foo.bar.trim())
+          """
+      do {
+        _ = try TestRenderer(sources: .singleSource(test)).render(path: "missingParam", context: [:]).wait()
+        XCTFail("Should have thrown LeafError.missingParameter")
+      } catch let error as LeafError {
+        switch error.reason {
+        case .missingParameter:
+          return
+        default:
+          XCTFail("Wrong error: \(error.localizedDescription)")
+        }
+      } catch {
+        XCTFail("Wrong error: \(error.localizedDescription)")
+      }
+    }
 }

--- a/Tests/LeafKitTests/LeafErrorTests.swift
+++ b/Tests/LeafKitTests/LeafErrorTests.swift
@@ -57,8 +57,9 @@ final class LeafErrorTests: XCTestCase {
             .render(path: "missingParam", context: [:])
             .wait()
         ) {
-            guard case .missingParameter = ($0 as? LeafError)?.reason else {
-                return XCTFail("Expected LeafError.missingParameter, got \(String(reflecting: $0))")
+            guard case .unknownError("Found nil while iterating through params") = ($0 as? LeafError)?.reason else {
+                return XCTFail("Expected LeafError.unknownError(\"Found nil while iterating through params\"), got \(String(reflecting: $0))")
             }
         }
+    }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
This line https://github.com/vapor/leaf-kit/blob/main/Sources/LeafKit/LeafParser/LeafParser.swift#L203
would cause a crash when no parameters are found
<!-- When this PR is merged, the title and body will be -->
Fixed issue that lead to a crash when parameters would be empty in line https://github.com/vapor/leaf-kit/blob/main/Sources/LeafKit/LeafParser/LeafParser.swift#L203
<!-- used to generate a release automatically. -->
