### PR TITLE
Add support for time zones in `DateTag`.

### DIFF
--- a/Sources/LeafKit/LeafSyntax/LeafTag.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafTag.swift
@@ -87,6 +87,15 @@ struct DateTag: LeafTag {
                 throw "Unable to convert date format to string"
             }
             formatter.dateFormat = string
+        case 3:
+            guard let string = ctx.parameters[1].string else {
+                throw "Unable to convert date format to string"
+            }
+            formatter.dateFormat = string
+            guard let timeZone = ctx.parameters[2].string else {
+                throw "Unable to convert time zone to string"
+            }
+            formatter.timeZone = TimeZone(identifier: timeZone)
         default:
             throw "invalid parameters provided for date"
         }

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -216,7 +216,7 @@ class TagTests: XCTestCase {
         """
 
         let expectedNewYork = """
-        The date is 2020-11-09T07:30
+        The date is 2020-11-09T09:30
         """
         
         try XCTAssertEqual(render(templateNewYork, ["now": .int(now)]), expectedNewYork)
@@ -226,7 +226,7 @@ class TagTests: XCTestCase {
         """
 
         let expectedCalifornia = """
-        The date is 2020-11-09T04:30
+        The date is 2020-11-09T06:30
         """
         
         try XCTAssertEqual(render(templateCalifornia, ["now": .int(now)]), expectedCalifornia)

--- a/Tests/LeafKitTests/TagTests.swift
+++ b/Tests/LeafKitTests/TagTests.swift
@@ -208,6 +208,30 @@ class TagTests: XCTestCase {
         try XCTAssertEqual(render(template, ["now": .int(now)]), expected)
     }
 
+    func testDateWithCustomFormatAndTimeZone() throws {
+        let now = 1604932200 - Calendar.current.timeZone.secondsFromGMT()
+        
+        let templateNewYork = """
+        The date is #date(now, "yyyy-MM-dd'T'HH:mm", "America/New_York")
+        """
+
+        let expectedNewYork = """
+        The date is 2020-11-09T07:30
+        """
+        
+        try XCTAssertEqual(render(templateNewYork, ["now": .int(now)]), expectedNewYork)
+        
+        let templateCalifornia = """
+        The date is #date(now, "yyyy-MM-dd'T'HH:mm", "America/Los_Angeles")
+        """
+
+        let expectedCalifornia = """
+        The date is 2020-11-09T04:30
+        """
+        
+        try XCTAssertEqual(render(templateCalifornia, ["now": .int(now)]), expectedCalifornia)
+    }
+
     func testDumpContext() throws {
         let data: [String: LeafData] = ["value": 12345]
         let template = """


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Adds an additional parameter to `DateTag` that takes a time zone ID and uses it to set the `timeZone` property of the `DateFormatter`.

For example (as you can see in the added tests):
```leaf
The date is #date(now, "yyyy-MM-dd'T'HH:mm", "America/New_York")
```
will be three hours ahead of:
```leaf
The date is #date(now, "yyyy-MM-dd'T'HH:mm", "America/Los_Angeles")
```

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
