### PR TITLE
Update to Swift 5.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,10 @@ env:
 
 jobs:
   unit-tests:
-     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    with:
+      with_musl: true
+      ios_scheme_name: leaf-kit
 
   leaf-integration:
     if: ${{ !(github.event.pull_request.draft || false) }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
@@ -19,8 +19,14 @@ let package = Package(
         .target(name: "LeafKit", dependencies: [
             .product(name: "NIO", package: "swift-nio"),
         ]),
-        .testTarget(name: "LeafKitTests", dependencies: [
-            .target(name: "LeafKit"),
-        ]),
+        .testTarget(
+            name: "LeafKitTests",
+            dependencies: [
+                .target(name: "LeafKit"),
+            ],
+            resources: [
+                .copy("Templates"),
+            ]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -10,23 +10,39 @@ let package = Package(
         .watchOS(.v6),
     ],
     products: [
-        .library(name: "LeafKit", targets: ["LeafKit"]),
+        .library(name: "LeafKit", targets: ["LeafKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0")
     ],
     targets: [
-        .target(name: "LeafKit", dependencies: [
-            .product(name: "NIO", package: "swift-nio"),
-        ]),
+        .target(
+            name: "LeafKit",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio")
+            ],
+            swiftSettings: swiftSettings
+        ),
         .testTarget(
             name: "LeafKitTests",
             dependencies: [
-                .target(name: "LeafKit"),
+                .target(name: "LeafKit")
             ],
             resources: [
-                .copy("Templates"),
-            ]
+                .copy("Templates")
+            ],
+            swiftSettings: swiftSettings
         ),
     ]
 )
+
+var swiftSettings: [SwiftSetting] {
+    [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("ConciseMagicFile"),
+        .enableUpcomingFeature("ForwardTrailingClosures"),
+        .enableUpcomingFeature("DisableOutwardActorInference"),
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency=complete"),
+    ]
+}

--- a/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
+++ b/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
@@ -73,7 +73,7 @@ public final class DefaultLeafCache: SynchronousLeafCache {
     
     // MARK: - Internal Only
     
-    internal let lock: Lock
+    internal let lock: NIOLock
     internal var cache: [String: LeafAST]
     
     /// Blocking file load behavior

--- a/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
+++ b/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
@@ -22,7 +22,7 @@ public final class DefaultLeafCache: SynchronousLeafCache {
     /// - Returns: The document provided as an identity return
     public func insert(
         _ document: LeafAST,
-        on loop: EventLoop,
+        on loop: any EventLoop,
         replace: Bool = false
     ) -> EventLoopFuture<LeafAST> {
         // future fails if caching is enabled
@@ -44,7 +44,7 @@ public final class DefaultLeafCache: SynchronousLeafCache {
     /// - Returns: `EventLoopFuture<LeafAST?>` holding the `LeafAST` or nil if no matching result
     public func retrieve(
         documentName: String,
-        on loop: EventLoop
+        on loop: any EventLoop
     ) -> EventLoopFuture<LeafAST?> {
         guard isEnabled == true else { return loop.makeSucceededFuture(nil) }
         self.lock.lock()
@@ -59,7 +59,7 @@ public final class DefaultLeafCache: SynchronousLeafCache {
     ///     returns true. If cache can't remove because of dependencies (not yet possible), returns false.
     public func remove(
         _ documentName: String,
-        on loop: EventLoop
+        on loop: any EventLoop
     ) -> EventLoopFuture<Bool?> {
         guard isEnabled == true else { return loop.makeFailedFuture(LeafError(.cachingDisabled)) }
 

--- a/Sources/LeafKit/LeafCache/LeafCache.swift
+++ b/Sources/LeafKit/LeafCache/LeafCache.swift
@@ -25,7 +25,7 @@ public protocol LeafCache {
     /// - Returns: The document provided as an identity return (or a failed future if it can't be inserted)
     func insert(
         _ document: LeafAST,
-        on loop: EventLoop,
+        on loop: any EventLoop,
         replace: Bool
     ) -> EventLoopFuture<LeafAST>
     
@@ -35,7 +35,7 @@ public protocol LeafCache {
     /// - Returns: `EventLoopFuture<LeafAST?>` holding the `LeafAST` or nil if no matching result
     func retrieve(
         documentName: String,
-        on loop: EventLoop
+        on loop: any EventLoop
     ) -> EventLoopFuture<LeafAST?>
 
     /// - Parameters:
@@ -45,7 +45,7 @@ public protocol LeafCache {
     ///     returns true. If cache can't remove because of dependencies (not yet possible), returns false.
     func remove(
         _ documentName: String,
-        on loop: EventLoop
+        on loop: any EventLoop
     ) -> EventLoopFuture<Bool?>
 }
 

--- a/Sources/LeafKit/LeafData/LeafData.swift
+++ b/Sources/LeafKit/LeafData/LeafData.swift
@@ -105,7 +105,7 @@ public struct LeafData: CustomStringConvertible,
     }
     
     // MARK: - Generic `LeafDataRepresentable` Initializer
-    public init(_ leafData: LeafDataRepresentable) { self = leafData.leafData }
+    public init(_ leafData: any LeafDataRepresentable) { self = leafData.leafData }
 
     // MARK: - Static Initializer Conformances
     /// Creates a new `LeafData` from a `Bool`.

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -18,23 +18,23 @@ public final class LeafRenderer {
     /// A keyed dictionary of custom `LeafTags` to extend Leaf's basic functionality, registered
     /// with the names which will call them when rendering - eg `tags["tagName"]` can be used
     /// in a template as `#tagName(parameters)`
-    public let tags: [String: LeafTag]
+    public let tags: [String: any LeafTag]
     /// A thread-safe implementation of `LeafCache` protocol
-    public let cache: LeafCache
+    public let cache: any LeafCache
     /// A thread-safe implementation of `LeafSource` protocol
     public let sources: LeafSources
     /// The NIO `EventLoop` on which this instance of `LeafRenderer` will operate
-    public let eventLoop: EventLoop
+    public let eventLoop: any EventLoop
     /// Any custom instance data to use (eg, in Vapor, the `Application` and/or `Request` data)
     public let userInfo: [AnyHashable: Any]
     
     /// Initial configuration of LeafRenderer.
     public init(
         configuration: LeafConfiguration,
-        tags: [String: LeafTag] = defaultTags,
-        cache: LeafCache = DefaultLeafCache(),
+        tags: [String: any LeafTag] = defaultTags,
+        cache: any LeafCache = DefaultLeafCache(),
         sources: LeafSources,
-        eventLoop: EventLoop,
+        eventLoop: any EventLoop,
         userInfo: [AnyHashable: Any] = [:]
     ) {
         self.configuration = configuration
@@ -217,7 +217,7 @@ public final class LeafRenderer {
     
     private func getFlatCachedHit(_ path: String) -> LeafAST? {
         // If cache provides blocking load, try to get a flat AST immediately
-        guard let blockingCache = cache as? SynchronousLeafCache,
+        guard let blockingCache = cache as? any SynchronousLeafCache,
            let cached = try? blockingCache.retrieve(documentName: path),
            cached.flat else { return nil }
         return cached

--- a/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
+++ b/Sources/LeafKit/LeafSerialize/LeafSerializer.swift
@@ -5,7 +5,7 @@ internal struct LeafSerializer {
     
     init(
         ast: [Syntax],
-        tags: [String: LeafTag] = defaultTags,
+        tags: [String: any LeafTag] = defaultTags,
         userInfo: [AnyHashable: Any] = [:],
         ignoreUnfoundImports: Bool
         
@@ -34,7 +34,7 @@ internal struct LeafSerializer {
     private let ast: [Syntax]
     private var offset: Int
     private var buffer: ByteBuffer
-    private let tags: [String: LeafTag]
+    private let tags: [String: any LeafTag]
     private let userInfo: [AnyHashable: Any]
     private let ignoreUnfoundImports: Bool
 
@@ -94,7 +94,7 @@ internal struct LeafSerializer {
 
         let leafData: LeafData
 
-        if foundTag is UnsafeUnescapedLeafTag {
+        if foundTag is any UnsafeUnescapedLeafTag {
             leafData = try foundTag.render(sub)
         } else {
             leafData = try foundTag.render(sub).htmlEscaped()

--- a/Sources/LeafKit/LeafSerialize/ParameterResolver.swift
+++ b/Sources/LeafKit/LeafSerialize/ParameterResolver.swift
@@ -14,7 +14,7 @@ internal struct ParameterResolver {
     
     let params: [ParameterDeclaration]
     let data: [String: LeafData]
-    let tags: [String: LeafTag]
+    let tags: [String: any LeafTag]
     let userInfo: [AnyHashable: Any]
 
     func resolve() throws -> [ResolvedParameter] {

--- a/Sources/LeafKit/LeafSource/LeafSource.swift
+++ b/Sources/LeafKit/LeafSource/LeafSource.swift
@@ -12,5 +12,5 @@ public protocol LeafSource {
     ///            template, or an appropriate failed state ELFuture (not found, illegal access, etc)
     func file(template: String,
               escape: Bool,
-              on eventLoop: EventLoop) throws -> EventLoopFuture<ByteBuffer>
+              on eventLoop: any EventLoop) throws -> EventLoopFuture<ByteBuffer>
 }

--- a/Sources/LeafKit/LeafSource/LeafSources.swift
+++ b/Sources/LeafKit/LeafSource/LeafSources.swift
@@ -31,7 +31,7 @@ public final class LeafSources {
     ///   - searchable: Whether the source should be added to the default search path
     /// - Throws: Attempting to overwrite a previously named source is not permitted
     public func register(source key: String = "default",
-                         using source: LeafSource,
+                         using source: any LeafSource,
                          searchable: Bool = true) throws {
         try lock.withLock {
             guard !sources.keys.contains(key) else { throw "Can't replace source at \(key)" }
@@ -43,19 +43,19 @@ public final class LeafSources {
     /// Convenience for initializing a `LeafSources` object with a single `LeafSource`
     /// - Parameter source: A fully configured `LeafSource`
     /// - Returns: Configured `LeafSource` instance
-    public static func singleSource(_ source: LeafSource) -> LeafSources {
+    public static func singleSource(_ source: any LeafSource) -> LeafSources {
         let sources = LeafSources()
         try! sources.register(using: source)
         return sources
     }
     
     // MARK: - Internal Only
-    internal private(set) var sources: [String: LeafSource]
+    internal private(set) var sources: [String: any LeafSource]
     private var order: [String]
     private let lock: NIOLock = .init()
     
     /// Locate a template from the sources; if a specific source is named, only try to read from it. Otherwise, use the specified search order
-    internal func find(template: String, in source: String? = nil, on eventLoop: EventLoop) throws -> EventLoopFuture<(String, ByteBuffer)> {
+    internal func find(template: String, in source: String? = nil, on eventLoop: any EventLoop) throws -> EventLoopFuture<(String, ByteBuffer)> {
         var keys: [String]
         
         switch source {
@@ -69,7 +69,7 @@ public final class LeafSources {
         return searchSources(t: template, on: eventLoop, s: keys)
     }
     
-    private func searchSources(t: String, on eL: EventLoop, s: [String]) -> EventLoopFuture<(String, ByteBuffer)> {
+    private func searchSources(t: String, on eL: any EventLoop, s: [String]) -> EventLoopFuture<(String, ByteBuffer)> {
         guard !s.isEmpty else { return eL.makeFailedFuture(LeafError(.noTemplateExists(t))) }
         var more = s
         let key = more.removeFirst()

--- a/Sources/LeafKit/LeafSource/LeafSources.swift
+++ b/Sources/LeafKit/LeafSource/LeafSources.swift
@@ -52,7 +52,7 @@ public final class LeafSources {
     // MARK: - Internal Only
     internal private(set) var sources: [String: LeafSource]
     private var order: [String]
-    private let lock: Lock = .init()
+    private let lock: NIOLock = .init()
     
     /// Locate a template from the sources; if a specific source is named, only try to read from it. Otherwise, use the specified search order
     internal func find(template: String, in source: String? = nil, on eventLoop: EventLoop) throws -> EventLoopFuture<(String, ByteBuffer)> {

--- a/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
+++ b/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
@@ -69,7 +69,7 @@ public struct NIOLeafFiles: LeafSource {
     ///   - eventLoop: `EventLoop` on which to perform file access
     /// - Returns: A succeeded `EventLoopFuture` holding a `ByteBuffer` with the raw
     ///            template, or an appropriate failed state ELFuture (not found, illegal access, etc)
-    public func file(template: String, escape: Bool = false, on eventLoop: EventLoop) throws -> EventLoopFuture<ByteBuffer> {
+    public func file(template: String, escape: Bool = false, on eventLoop: any EventLoop) throws -> EventLoopFuture<ByteBuffer> {
         var template = URL(fileURLWithPath: sandbox + viewRelative + template, isDirectory: false).standardized.path
         /// If default extension is enforced for template files, add it if it's not on the file, or if no extension present
         if limits.contains(.onlyLeafExtensions), !template.hasSuffix(".\(self.extension)")
@@ -108,7 +108,7 @@ public struct NIOLeafFiles: LeafSource {
     internal let `extension`: String
     
     /// Attempt to read a fully pathed template and return a ByteBuffer or fail
-    private func read(path: String, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+    private func read(path: String, on eventLoop: any EventLoop) -> EventLoopFuture<ByteBuffer> {
         let openFile = self.fileio.openFile(path: path, eventLoop: eventLoop)
         return openFile.flatMapErrorThrowing { error in
             throw LeafError(.noTemplateExists(path))

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -81,12 +81,12 @@ public enum ConditionalSyntax {
 extension Syntax: BodiedSyntax  {
     internal func externals() -> Set<String> {
         switch self {
-            case .conditional(let bS as BodiedSyntax),
-                 .custom(let bS as BodiedSyntax),
-                 .export(let bS as BodiedSyntax),
-                 .extend(let bS as BodiedSyntax),
-                 .with(let bS as BodiedSyntax),
-                 .loop(let bS as BodiedSyntax): return bS.externals()
+            case .conditional(let bS as any BodiedSyntax),
+                 .custom(let bS as any BodiedSyntax),
+                 .export(let bS as any BodiedSyntax),
+                 .extend(let bS as any BodiedSyntax),
+                 .with(let bS as any BodiedSyntax),
+                 .loop(let bS as any BodiedSyntax): return bS.externals()
             default: return .init()
         }
     }
@@ -94,12 +94,12 @@ extension Syntax: BodiedSyntax  {
     internal func imports() -> Set<String> {
         switch self {
             case .import(let i): return .init(arrayLiteral: i.key)
-            case .conditional(let bS as BodiedSyntax),
-                 .custom(let bS as BodiedSyntax),
-                 .export(let bS as BodiedSyntax),
-                 .extend(let bS as BodiedSyntax),
-                 .expression(let bS as BodiedSyntax),
-                 .loop(let bS as BodiedSyntax): return bS.imports()
+            case .conditional(let bS as any BodiedSyntax),
+                 .custom(let bS as any BodiedSyntax),
+                 .export(let bS as any BodiedSyntax),
+                 .extend(let bS as any BodiedSyntax),
+                 .expression(let bS as any BodiedSyntax),
+                 .loop(let bS as any BodiedSyntax): return bS.imports()
             // .variable, .raw
             default: return .init()
         }
@@ -122,12 +122,12 @@ extension Syntax: BodiedSyntax  {
                     result.append(self)
                 }
             // Recursively inline single Syntaxes
-            case .conditional(let bS as BodiedSyntax),
-                 .custom(let bS as BodiedSyntax),
-                 .export(let bS as BodiedSyntax),
-                 .extend(let bS as BodiedSyntax),
-                 .with(let bS as BodiedSyntax),
-                 .loop(let bS as BodiedSyntax): result += bS.inlineRefs(externals, imports)
+            case .conditional(let bS as any BodiedSyntax),
+                 .custom(let bS as any BodiedSyntax),
+                 .export(let bS as any BodiedSyntax),
+                 .extend(let bS as any BodiedSyntax),
+                 .with(let bS as any BodiedSyntax),
+                 .loop(let bS as any BodiedSyntax): result += bS.inlineRefs(externals, imports)
             case .expression(let pDA): result.append(.expression(pDA.inlineImports(imports)))
             // .variable, .raw
             default: result.append(self)

--- a/Sources/LeafKit/LeafSyntax/LeafTag.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafTag.swift
@@ -8,7 +8,7 @@ public protocol LeafTag {
 /// Tags conforming to this protocol do not get their contents HTML-escaped.
 public protocol UnsafeUnescapedLeafTag: LeafTag {}
 
-public var defaultTags: [String: LeafTag] = [
+public var defaultTags: [String: any LeafTag] = [
     "unsafeHTML": UnsafeHTML(),
     "lowercased": Lowercased(),
     "uppercased": Uppercased(),

--- a/Tests/LeafKitTests/TestHelpers.swift
+++ b/Tests/LeafKitTests/TestHelpers.swift
@@ -49,7 +49,7 @@ internal func render(name: String = "test-render", _ template: String, _ context
 /// Helper wrapping` LeafRenderer` to preconfigure for simplicity & allow eliding context
 internal class TestRenderer {
     var r: LeafRenderer
-    private let lock: Lock
+    private let lock: NIOLock
     private var counter: Int = 0
     
     init(configuration: LeafConfiguration = .init(rootDirectory: "/"),
@@ -88,7 +88,7 @@ internal class TestRenderer {
 /// Helper `LeafFiles` struct providing an in-memory thread-safe map of "file names" to "file data"
 internal struct TestFiles: LeafSource {
     var files: [String: String]
-    var lock: Lock
+    var lock: NIOLock
     
     init() {
         files = [:]

--- a/Tests/LeafKitTests/TestHelpers.swift
+++ b/Tests/LeafKitTests/TestHelpers.swift
@@ -53,10 +53,10 @@ internal class TestRenderer {
     private var counter: Int = 0
     
     init(configuration: LeafConfiguration = .init(rootDirectory: "/"),
-            tags: [String : LeafTag] = defaultTags,
-            cache: LeafCache = DefaultLeafCache(),
+            tags: [String : any LeafTag] = defaultTags,
+            cache: any LeafCache = DefaultLeafCache(),
             sources: LeafSources = .singleSource(TestFiles()),
-            eventLoop: EventLoop = EmbeddedEventLoop(),
+            eventLoop: any EventLoop = EmbeddedEventLoop(),
             userInfo: [AnyHashable : Any] = [:]) {
         self.r = .init(configuration: configuration,
                               tags: tags,
@@ -95,7 +95,7 @@ internal struct TestFiles: LeafSource {
         lock = .init()
     }
     
-    public func file(template: String, escape: Bool = false, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+    public func file(template: String, escape: Bool = false, on eventLoop: any EventLoop) -> EventLoopFuture<ByteBuffer> {
         var path = template
         if path.split(separator: "/").last?.split(separator: ".").count ?? 1 < 2,
            !path.hasSuffix(".leaf") { path += ".leaf" }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
- Update `swift-tools-version` to 5.9
- Add common `swiftSettings` to targets
- Fix unhandled files warnings
    - `Templates` folder in test target; added to target's resources
    - `Docs.docc` folder in main target; updating `swift-tools-version` fixes it
- `Lock` was deprecated in favour of `NIOLock`
- Add MUSL and iOS in CI

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
