### PR TITLE
Fix comparisons between non-`nil` values and `nil`

### DIFF
--- a/Sources/LeafKit/LeafData/LeafData.swift
+++ b/Sources/LeafKit/LeafData/LeafData.swift
@@ -74,7 +74,7 @@ public struct LeafData:
         }
         // If either side is nil, false - storage == would have returned false
         if lhs.isNil || rhs.isNil {
-            return true
+            return false
         }
         // Fuzzy comparison by string casting
         guard lhs.isCastable(to: .string),

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -34,6 +34,20 @@ final class LeafTests: XCTestCase {
         XCTAssertEqual(rendered, expectation)
     }
 
+    func testNilIf() throws {
+        let template = """
+        #if(a != nil): not nil #else: nil #endif
+        """
+
+        let expectation = """
+         not nil 
+        """
+
+        let rendered = try render(template, ["a": .string("hello")])
+
+        XCTAssertEqual(rendered, expectation)
+    }
+
     func testRaw() throws {
         let template = "Hello!"
         try XCTAssertEqual(render(template), "Hello!")


### PR DESCRIPTION
The changes in #135 introduced a nasty bug where conditions of the form `#if (value == nil)` or `#if (value != nil)` would incorrectly treat `nil` as equal to any non-`nil` value. Unfortunately, there was no test for this case, so the problem was not caught. This fixes the issue and adds the missing test.