### PR TITLE
Fix build error with NIO 2.86.1 and bump minimum Swift version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -40,8 +40,9 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("ConciseMagicFile"),
-    .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ] }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/leaf-kit/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/leaf-kit/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
-<a href="https://codecov.io/github/vapor/leaf-kit"><img src="https://img.shields.io/codecov/c/github/vapor/leaf-kit?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
+<a href="https://codecov.io/github/vapor/leaf-kit"><img src="https://img.shields.io/codecov/c/github/vapor/leaf-kit?style=plastic&logo=codecov&label=codecov" alt="Code Coverage"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift60up.svg" alt="Swift 6.0+"></a>
 </p>
 
 <br>

--- a/Sources/LeafKit/Docs.docc/theme-settings.json
+++ b/Sources/LeafKit/Docs.docc/theme-settings.json
@@ -1,6 +1,6 @@
 {
   "theme": {
-    "aside": { "border-radius": "16px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-width": "3px", "border-style": "double" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
@@ -8,14 +8,14 @@
       "leaf": { "dark": "hsl(136, 43%, 53%)", "light": "hsl(136, 33%, 48%)" },
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-leaf) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-leaf)",
-      "documentation-intro-eyebrow": "white",
+      "hero-eyebrow": "white",
       "documentation-intro-figure": "white",
-      "documentation-intro-title": "white",
+      "hero-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/leafkit/images/vapor-leafkit-logo.svg" }
+    "icons": { "technology": "/leafkit/images/LeafKit/vapor-leafkit-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
+++ b/Sources/LeafKit/LeafCache/DefaultLeafCache.swift
@@ -1,4 +1,5 @@
-import NIOCore
+public import protocol NIOCore.EventLoop
+public import class NIOCore.EventLoopFuture
 import NIOConcurrencyHelpers
 
 public final class DefaultLeafCache: SynchronousLeafCache {

--- a/Sources/LeafKit/LeafCache/LeafCache.swift
+++ b/Sources/LeafKit/LeafCache/LeafCache.swift
@@ -1,4 +1,5 @@
-import NIOCore
+public import protocol NIOCore.EventLoop
+public import class NIOCore.EventLoopFuture
 
 /// `LeafCache` provides blind storage for compiled `LeafAST` objects.
 ///

--- a/Sources/LeafKit/LeafConfiguration.swift
+++ b/Sources/LeafKit/LeafConfiguration.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation // there is no syntax to allow importing only String.Encoding 
 import NIOConcurrencyHelpers
 
 /// General configuration of Leaf

--- a/Sources/LeafKit/LeafData/LeafData.swift
+++ b/Sources/LeafKit/LeafData/LeafData.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import struct Foundation.Data
 import NIOCore
 
 /// `LeafData` is a "pseudo-protocol" wrapping the physically storable Swift data types

--- a/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
+++ b/Sources/LeafKit/LeafData/LeafDataRepresentable.swift
@@ -1,4 +1,5 @@
-import Foundation
+public import struct Foundation.Date
+public import struct Foundation.UUID
 
 /// Capable of being encoded as `LeafData`.
 public protocol LeafDataRepresentable {

--- a/Sources/LeafKit/LeafLexer/LeafLexer.swift
+++ b/Sources/LeafKit/LeafLexer/LeafLexer.swift
@@ -223,11 +223,12 @@ struct LeafLexer {
 
             let next = self.src.peek()!
             let peekRaw = String(current) + (self.src.peekWhile { $0.isValidInNumeric })
-            #if swift(>=6.0)
-            var peekNum = peekRaw.replacing(String(.underscore), with: "")
-            #else
-            var peekNum = peekRaw.replacingOccurrences(of: String(.underscore), with: "")
-            #endif
+            var peekNum: String
+            if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
+                peekNum = peekRaw.replacing(String(.underscore), with: "")
+            } else {
+                peekNum = peekRaw.replacingOccurrences(of: String(.underscore), with: "")
+            }
             // We must be immediately preceeded by a minus to flip the sign
             // And only flip back if immediately preceeded by a const, tag or variable
             // (which we assume will provide a numeric). Grammatical errors in the

--- a/Sources/LeafKit/LeafRenderer.swift
+++ b/Sources/LeafKit/LeafRenderer.swift
@@ -1,4 +1,6 @@
-import NIOCore
+public import protocol NIOCore.EventLoop
+public import class NIOCore.EventLoopFuture
+public import struct NIOCore.ByteBuffer
 
 // MARK: - `LeafRenderer` Summary
 

--- a/Sources/LeafKit/LeafSource/LeafSource.swift
+++ b/Sources/LeafKit/LeafSource/LeafSource.swift
@@ -1,4 +1,6 @@
-import NIOCore
+public import struct NIOCore.ByteBuffer
+public import protocol NIOCore.EventLoop
+public import class NIOCore.EventLoopFuture
 
 /// Public protocol to adhere to in order to provide template source originators to `LeafRenderer`
 public protocol LeafSource {

--- a/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
+++ b/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
@@ -1,7 +1,9 @@
 import Foundation
-import NIOCore
+public import struct NIOCore.ByteBuffer
+public import protocol NIOCore.EventLoop
+public import class NIOCore.EventLoopFuture
 import _NIOFileSystem
-import NIOPosix
+public import struct NIOPosix.NonBlockingFileIO
 
 /// Reference and default implementation of `LeafSource` adhering object that provides a non-blocking
 /// file reader for `LeafRenderer`

--- a/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
+++ b/Sources/LeafKit/LeafSource/NIOLeafFiles.swift
@@ -1,6 +1,6 @@
 import Foundation
 import NIOCore
-import NIOFileSystem
+import _NIOFileSystem
 import NIOPosix
 
 /// Reference and default implementation of `LeafSource` adhering object that provides a non-blocking

--- a/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
+++ b/Sources/LeafKit/LeafSyntax/LeafSyntax.swift
@@ -1,4 +1,4 @@
-import NIOCore
+public import struct NIOCore.ByteBuffer
 
 public indirect enum Syntax: Sendable {
     // MARK: .raw - Makeable, Entirely Readable

--- a/Sources/LeafKit/String+HTMLEscape.swift
+++ b/Sources/LeafKit/String+HTMLEscape.swift
@@ -3,21 +3,20 @@ import Foundation
 extension String {
     /// Escapes HTML entities in a `String`.
     public func htmlEscaped() -> String {
-        #if swift(>=6.0)
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
-            return self
+            self
                 .replacing("&", with: "&amp;")
                 .replacing("\"", with: "&quot;")
                 .replacing("'", with: "&#39;")
                 .replacing("<", with: "&lt;")
                 .replacing(">", with: "&gt;")
+        } else {
+            self
+                .replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "\"", with: "&quot;")
+                .replacingOccurrences(of: "'", with: "&#39;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
         }
-        #endif
-        return self
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
     }
 }

--- a/Tests/LeafKitTests/LeafSerializerTests.swift
+++ b/Tests/LeafKitTests/LeafSerializerTests.swift
@@ -1,4 +1,5 @@
 @testable import LeafKit
+import NIOCore
 import XCTest
 
 final class SerializerTests: XCTestCase {

--- a/Tests/LeafKitTests/LeafTests.swift
+++ b/Tests/LeafKitTests/LeafTests.swift
@@ -1,4 +1,5 @@
 @testable import LeafKit
+import NIOCore
 import XCTest
 
 final class LeafTests: XCTestCase {


### PR DESCRIPTION
Fixes the incorrect import of the non-underscored `NIOFileSystem` module; we now correctly import `_NIOFileSystem`. The minimum Swift version requirement is now 6.0, thanks to the release of Swift 6.2.0.

Closes #141.